### PR TITLE
feat: add bounded cursor_do delegation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "vanyangyang",
-  "description": "Vanyangyang 的 Claude Code 插件市场——目前提供 cursor-bridge（驱动 Cursor 做语义检索）。",
+  "description": "Vanyangyang 的 Claude Code 插件市场——目前提供 cursor-bridge（驱动 Cursor 做语义检索与边界明确的委托执行）。",
   "owner": {
     "name": "Vanyangyang"
   },
@@ -8,8 +8,8 @@
     {
       "name": "cursor-bridge",
       "source": ".",
-      "description": "从 Claude Code 直驱 Cursor IDE 的 agent 做语义代码检索（CDP 直驱，无 console 注入）。需 Cursor 带 --remote-debugging-port=9223 在跑。",
-      "version": "2.0.7",
+      "description": "从 Claude Code 直驱 Cursor IDE agent 做语义检索与委托执行，支持 FIFO 和安全的顶层 Agent 并行模式。需 Cursor 带 --remote-debugging-port=9223 在跑。",
+      "version": "2.1.0",
       "author": {
         "name": "Vanyangyang"
       }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cursor-bridge",
-  "version": "2.0.7",
-  "description": "MCP server: 从 Claude Code 直驱 Cursor IDE 的 agent 做语义代码检索（CDP 直驱，无 console 注入）。",
+  "version": "2.1.0",
+  "description": "从 Claude Code 直驱 Cursor IDE agent 做语义检索与边界明确的委托执行，支持 FIFO 和安全的顶层 Agent 并行模式。",
   "author": {
     "name": "Vanyangyang"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cursor-bridge",
-  "version": "2.0.7",
-  "description": "MCP server: drive Cursor IDE's agent for semantic code search over CDP.",
+  "version": "2.1.0",
+  "description": "Drive Cursor IDE agents over CDP for semantic search and bounded delegated execution, including safe top-level Agent parallelism.",
   "author": {
     "name": "Vanyangyang"
   },
@@ -19,8 +19,8 @@
   },
   "interface": {
     "displayName": "Cursor Bridge",
-    "shortDescription": "Drive Cursor semantic search from Codex over CDP.",
-    "longDescription": "Expose cursor_search, cursor_status, and cursor_launch so Codex can ask Cursor IDE for project-aware semantic search through its agent, without console injection.",
+    "shortDescription": "Delegate bounded work to Cursor with safe Agent parallelism.",
+    "longDescription": "Expose cursor_search, cursor_do, cursor_status, and cursor_launch. Cursor Bridge can retain FIFO compatibility or submit independent bounded tasks to separate top-level Cursor Agents, track them by stable agent ID, and collect each result without using Cursor /multitask.",
     "developerName": "Vanyangyang",
     "category": "Developer Tools",
     "capabilities": [
@@ -28,7 +28,8 @@
     ],
     "defaultPrompt": [
       "Use Cursor Bridge to search this project with Cursor's semantic agent.",
-      "Check whether Cursor Bridge can launch Cursor with CDP and report status."
+      "Use cursor_do to delegate this planned bounded task, then query cursor_status and verify the real result.",
+      "Submit these independent non-overlapping tasks as separate top-level Cursor Agents and collect them by task ID."
     ],
     "websiteURL": "https://github.com/Vanyangyang/cursor-bridge"
   }

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # cursor-bridge
 
-> MCP server：让 **Claude Code 直驱 Cursor IDE 里的 agent 做代码检索**（语义搜索 + Instant Grep，agent 自动编排）。
+> MCP server：让 **Codex/Claude Code 直驱 Cursor IDE agent 做语义检索与边界明确的委托执行**。
 > **CDP 直驱架构，无 console 注入、无 WebSocket 回连。**
 
-借用 Cursor 原生 embedding 的语义召回质量，给主调 agent（Claude Code 等 MCP 客户端）补一个「按意图做语义代码定位」的能力。
+借用 Cursor 原生 embedding 和执行能力，为主 Agent 提供语义定位、FIFO 委托，以及不依赖 `/multitask` 的独立顶层 Agent 并行池。
 
 ## 优点
 
@@ -13,12 +13,12 @@
 ## 架构
 
 ```
-Claude Code  --(MCP stdio)-->  cursor-bridge server  --(CDP :9223 Runtime.evaluate + Input)-->  Cursor 渲染进程
+Codex / Claude Code  --(MCP stdio)-->  cursor-bridge server  --(CDP :9223 Runtime.evaluate + Input)-->  Cursor 渲染进程
 ```
 
-- server 每次查询新建一条 CDP 连接（**串行**，GUI 单输入框一次只能跑一个），直接驱动 Cursor 的 chat DOM + 真实键盘事件。
+- GUI 操作通过互斥锁串行，避免多个任务同时争抢输入框；`parallel_agent` 提交完成后，各顶层 Cursor Agent 可并行运行，再按稳定 `agentId` 逐项取回。
 - Cursor 的语义搜索没有纯检索接口/独立 UI，只能经 `@Codebase`/agent chat 跑：填查询 → 真实 Enter → 等生成完成 → 抓回复。
-- 完成信号 = 停止钮（`codicon-stop` 等）数量从 `>0 → 0`。
+- FIFO 完成信号来自停止钮（`codicon-stop` 等）与回复稳定性；`parallel_agent` 还会结合 Agent History 状态和稳定 `agentId` 回收结果。
 
 > ⚠️ Cursor 是 agent（比纯检索更主动）。prompt 已强约束「只列 `path:行号`、不读正文、不改代码」，但这是 **prompt 约束而非技术沙箱**——理论上 agent 仍有写能力，勿当隔离环境。
 
@@ -49,7 +49,7 @@ claude plugin install cursor-bridge@vanyangyang
 codex plugin marketplace add Vanyangyang/cursor-bridge --ref master
 ```
 
-Codex 会读取仓库内 `.agents/plugins/marketplace.json` 和 `.codex-plugin/plugin.json`，注册同一套 `cursor_search` / `cursor_status` / `cursor_launch` MCP 工具。安装后开启新 Codex 线程或重启 Codex，让新插件工具进入当前会话。
+Codex 会读取仓库内 `.agents/plugins/marketplace.json` 和 `.codex-plugin/plugin.json`，注册 `cursor_search` / `cursor_do` / `cursor_status` / `cursor_launch`。安装后开启新 Codex 线程或重启 Codex，让新工具与 `cursor-delegate` skill 进入会话。
 
 ### 方式 C：从源码运行（开发/其它 MCP 客户端）
 
@@ -79,8 +79,11 @@ server 启动时会**自动确保 Cursor 带 CDP 在跑**（fire-and-forget）�
 | 工具 | 作用 |
 |------|------|
 | `cursor_search` | 用 Cursor agent 检索定位代码，入参 `query`（自然语言意图）。返回 `path:行号` 清单。单次约 ~90s（实测 66~175s 波动）、串行。 |
-| `cursor_status` | 检查与 Cursor CDP（9223）的连接/队列状态。 |
+| `cursor_do` | 委托边界明确的任务。`execution=fifo` 保持兼容；`execution=parallel_agent` 提交独立顶层 Agent。并行只读任务设 `read_only=true`；并行写任务必须给出两两不重叠的 `allowed_paths`。 |
+| `cursor_status` | 检查 CDP、队列、活动并行 Agent；传 `task_id` 精确取回对应状态与原始回复。 |
 | `cursor_launch` | 确保 Cursor 带 CDP 调试口在运行；未运行则自动拉起（带 `--remote-debugging-port` + `--remote-allow-origins` + 打开项目建索引）。返回 `already`/`launched`/`running-no-debug`/`port-not-cursor`/`no-exe`/`timeout`。 |
+
+`cursor_do` 默认以 `background=true`、`new_chat=true` 使用；主 Agent 保存返回的 `task_id`，再通过 `cursor_status(task_id)` 回收。`submitting`、`running`、`collecting` 都是正常进行态，超过两分钟本身不代表失败。Bridge 不要求唯一终止标记或最低回复长度。
 
 ## 环境变量
 
@@ -95,7 +98,9 @@ server 启动时会**自动确保 Cursor 带 CDP 在跑**（fire-and-forget）�
 ## 使用建议
 
 - ✅ 用于按「意图」做语义召回的代码定位、跨文件理解（借 Cursor 原生 embedding 质量）。
-- ⏱️ 单次约 ~90s 且串行（一次一个）。**建议并行使用**：丢后台 / 与其它工作并行推进，不要在主线阻塞等它返回。
+- ✅ 把 Cursor 当执行副手：产品方向、范围裁决和最终验证仍由主 Agent 负责。
+- 🔀 只有任务互不依赖且写入范围不重叠时才用 `parallel_agent`；其余情况使用 `fifo`。
+- 🪪 始终用 `task_id` 查询；并行任务还会绑定 Agents Window 的 `local:<UUID>`，不靠当前可见对话猜结果。
 
 ## 文件结构
 
@@ -112,6 +117,8 @@ dist/cursor-bridge.mjs # 打包产物：零依赖单文件（插件实际运行�
 server.mjs             # MCP server 源码主入口（CDP 直驱 + 工具定义）
 launch-cursor.mjs      # 确保/拉起带 CDP 的 Cursor
 build.mjs              # esbuild 打包脚本（npm run build → 重建 dist/）
+skills/cursor-delegate/ # 委托门禁、拆分、收回与主 Agent 复核规则
+test/                  # 调度、路径冲突与 Agent 身份选择的 node:test 门禁
 probe-*.mjs            # CDP 链路探针（实测脚本）
 agents-autopilot.mjs / autopilot-switch.py  # autopilot 辅助
 test-*.mjs             # 检索/批量自测脚本

--- a/dist/cursor-bridge.mjs
+++ b/dist/cursor-bridge.mjs
@@ -19333,6 +19333,7 @@ var CDP_PORT2 = Number(process.env.CURSOR_BRIDGE_CDP_PORT || 9223);
 var ORIGIN = `http://localhost:${CDP_PORT2}`;
 var QUERY_TIMEOUT = Number(process.env.CURSOR_BRIDGE_TIMEOUT || 18e4);
 var SEARCH_PREFIX = "\u53EA\u505A\u4EE3\u7801\u68C0\u7D22\u5B9A\u4F4D\uFF1A\u5217\u51FA\u4E0E\u4E0B\u9762\u610F\u56FE\u76F8\u5173\u7684\u6587\u4EF6\u8DEF\u5F84 + \u884C\u53F7\u8303\u56F4\uFF08\u5F62\u5982 Assets/Scripts/X.cs:120-180\uFF09\uFF0C\u9010\u884C\u5217\u51FA\u5373\u53EF\u3002\u4E0D\u8981\u8BFB\u53D6\u6587\u4EF6\u6B63\u6587\u3001\u4E0D\u8981\u4FEE\u6539\u4EFB\u4F55\u4EE3\u7801\u3001\u4E0D\u8981\u5C55\u5F00\u957F\u7BC7\u89E3\u91CA\u3002\n\n\u610F\u56FE\uFF1A";
+var DO_DEFAULT_CONTRACT = "\n\n\u5B8C\u6210\u8981\u6C42\uFF1A\u5728\u5F53\u524D Cursor \u5DF2\u6253\u5F00\u7684\u5DE5\u4F5C\u533A\u5185\u76F4\u63A5\u5B8C\u6210\u4EFB\u52A1\uFF1B\u4E0D\u8981\u63A8\u9001\u8FDC\u7AEF\u3002\u7ED3\u675F\u524D\u68C0\u67E5\u5B9E\u9645\u6539\u52A8\u5E76\u8FD0\u884C\u4E0E\u98CE\u9669\u5339\u914D\u7684\u9A8C\u8BC1\u3002\u6700\u7EC8\u56DE\u590D\u5FC5\u987B\u5217\u51FA\uFF1A\u5B8C\u6210\u5185\u5BB9\u3001\u6539\u52A8\u6587\u4EF6\u3001\u9A8C\u8BC1\u7ED3\u679C\u3001\u4ECD\u6709\u98CE\u9669\u6216\u963B\u585E\u3002";
 var CDP_HOST2 = "127.0.0.1";
 function httpJson(path) {
   return new Promise((resolve, reject) => {
@@ -19437,29 +19438,265 @@ function exprFill(text) {
   return `(function(){const inp=document.querySelector('.aislash-editor-input');if(!inp||inp.offsetParent===null)return 'NO_INPUT';inp.focus();try{const s=getSelection();const r=document.createRange();r.selectNodeContents(inp);s.removeAllRanges();s.addRange(r);}catch(e){}const ok=document.execCommand('insertText',false,${js});inp.dispatchEvent(new Event('input',{bubbles:true}));return ok?(inp.innerText||'').slice(0,30):'EXEC_FAIL';})()`;
 }
 var EXPR_SNAP = `(function(){
-  const md=[...document.querySelectorAll('.markdown-root,.aichat-container [class*=markdown]')];
-  let mdMax=0; for(const m of md){const t=(m.innerText||'').length; if(t>mdMax)mdMax=t;}
+  const md=[...document.querySelectorAll('.markdown-root,.aichat-container [class*=markdown]')]
+    .filter(e=>e.offsetParent!==null&&!e.closest('.ui-model-picker__trigger,[class*=model-picker]'));
+  const texts=md.map(m=>(m.innerText||'').trim()).filter(Boolean);
+  const last=texts[texts.length-1]||'';
+  let hash=0; for(let i=0;i<last.length;i++)hash=((hash<<5)-hash+last.charCodeAt(i))|0;
   const stop=[...document.querySelectorAll('[class*=codicon-stop],[class*=debug-stop],[aria-label*=Stop],[aria-label*=stop],[aria-label*=Cancel],[title*=Stop]')].filter(e=>e.offsetParent!==null).length;
-  return JSON.stringify({mdMax, stop});
+  return JSON.stringify({messageCount:texts.length,replyLength:last.length,replyHash:hash,stop});
 })()`;
 var EXPR_EXTRACT = `(function(){
-  const md=[...document.querySelectorAll('.markdown-root,.aichat-container [class*=markdown]')].filter(e=>e.offsetParent!==null);
-  let best=''; for(const m of md){const t=(m.innerText||'').trim(); if(t.length>best.length)best=t;}
-  return best;
+  const md=[...document.querySelectorAll('.markdown-root,.aichat-container [class*=markdown]')]
+    .filter(e=>e.offsetParent!==null&&!e.closest('.ui-model-picker__trigger,[class*=model-picker]'));
+  const texts=md.map(m=>(m.innerText||'').trim()).filter(Boolean);
+  return texts[texts.length-1]||'';
 })()`;
 var EXPR_FIND_NEWAGENT = `(function(){const b=[...document.querySelectorAll('button,[role=button],a.action-label,.codicon')].find(e=>e.offsetParent!==null&&/New Agent|New Chat/i.test(e.getAttribute('aria-label')||''));if(!b)return '';const r=b.getBoundingClientRect();return JSON.stringify({x:Math.round(r.x+r.width/2),y:Math.round(r.y+r.height/2)});})()`;
+var EXPR_HISTORY_OPEN = `(function(){return !![...document.querySelectorAll('.compact-agent-history-react-menu-label')].find(e=>e.offsetParent!==null);})()`;
+var EXPR_FIND_HISTORY = `(function(){const b=[...document.querySelectorAll('button,[role=button],a.action-label,.codicon')].find(e=>{if(e.offsetParent===null)return false;const s=(e.getAttribute('aria-label')||'')+' '+(e.getAttribute('title')||'');return /Show Chat History|Chat History|Agent History/i.test(s);});if(!b)return '';const r=b.getBoundingClientRect();return JSON.stringify({x:Math.round(r.x+r.width/2),y:Math.round(r.y+r.height/2)});})()`;
+var REACT_ADAPTER_BODY = `
+  const findAdapter=()=>{
+    const label=[...document.querySelectorAll('.compact-agent-history-react-menu-label')].find(e=>e.offsetParent!==null);
+    if(!label)return null;
+    const nodes=[]; let n=label;
+    for(let i=0;n&&i<18;i++,n=n.parentElement)nodes.push(n);
+    for(const node of nodes){
+      for(const key of Object.keys(node)){
+        if(!key.startsWith('__reactFiber$')&&!key.startsWith('__reactProps$'))continue;
+        const seed=node[key];
+        let f=key.startsWith('__reactFiber$')?seed:{memoizedProps:seed,return:null};
+        for(let j=0;f&&j<36;j++,f=f.return){
+          for(const p of [f.memoizedProps,f.pendingProps,f.stateNode&&f.stateNode.props]){
+            if(p&&Array.isArray(p.entries)&&typeof p.onOpenEntry==='function')return {props:p};
+          }
+        }
+      }
+    }
+    return null;
+  };
+  const a=findAdapter();`;
+var EXPR_HISTORY_ENTRIES = `(function(){${REACT_ADAPTER_BODY}
+  if(!a)return JSON.stringify({ok:false,error:'REACT_ADAPTER_UNAVAILABLE'});
+  const entries=a.props.entries.map((e,index)=>{
+    const raw=e.timestamp;
+    let timestamp=raw instanceof Date?raw.getTime():Number(raw);
+    if(!Number.isFinite(timestamp))timestamp=Date.parse(String(raw||''));
+    if(!Number.isFinite(timestamp))timestamp=index;
+    return {
+      id:String(e.id||''),label:String(e.label||''),searchText:String(e.searchText||''),timestamp,
+      isSelected:!!e.isSelected,showSpinner:!!e.showSpinner,
+      icon:String(typeof e.icon==='string'?e.icon:(e.icon&&((e.icon.id)||(e.icon.props&&e.icon.props.id)||(e.icon.type&&e.icon.type.id)))||'')
+    };
+  }).filter(e=>e.id);
+  return JSON.stringify({ok:true,entries});
+})()`;
+function exprOpenAgent(agentId) {
+  const id = JSON.stringify(String(agentId));
+  return `(function(){${REACT_ADAPTER_BODY}
+    if(!a)return 'REACT_ADAPTER_UNAVAILABLE';
+    const e=a.props.entries.find(x=>String(x.id||'')===${id}); if(!e)return 'AGENT_NOT_FOUND';
+    a.props.onOpenEntry(${id}); return 'OPENED';
+  })()`;
+}
+function normalizeAllowedPath(value) {
+  const raw = String(value || "").trim().replace(/\\/g, "/");
+  const prefix = /^[a-zA-Z]:/.test(raw) ? raw.slice(0, 2).toLowerCase() : "";
+  const body = prefix ? raw.slice(2) : raw;
+  const parts = [];
+  for (const part of body.split("/")) {
+    if (!part || part === ".") continue;
+    if (part === "..") {
+      if (parts.length > 0 && parts[parts.length - 1] !== "..") parts.pop();
+      else parts.push("..");
+    } else {
+      parts.push(part.toLowerCase());
+    }
+  }
+  const normalized = (prefix ? prefix + "/" : "") + parts.join("/");
+  return normalized || ".";
+}
+function pathsOverlap(a, b) {
+  const left = normalizeAllowedPath(a);
+  const right = normalizeAllowedPath(b);
+  return left === "." || right === "." || left === right || left.startsWith(right + "/") || right.startsWith(left + "/");
+}
+function selectNewAgentEntry(beforeEntries, afterEntries) {
+  const before = new Set((beforeEntries || []).map((e) => e.id));
+  const fresh = (afterEntries || []).map((e, index) => ({ ...e, _index: index })).filter((e) => e.id && !before.has(e.id));
+  if (fresh.length === 0) return null;
+  const selected = fresh.filter((e) => e.isSelected);
+  const pool = selected.length > 0 ? selected : fresh;
+  return [...pool].sort((a, b) => Number(b.timestamp || 0) - Number(a.timestamp || 0) || b._index - a._index)[0];
+}
 var CursorBridge = class {
   constructor() {
     this.busy = false;
     this.queue = [];
     this._healing = null;
+    this.tasks = /* @__PURE__ */ new Map();
+    this.nextTaskId = 1;
+    this.activeParallel = /* @__PURE__ */ new Map();
+    this._uiTail = Promise.resolve();
+    this._drainTimer = null;
+    this.parallelRestoreAgentId = null;
   }
   async search(query) {
     await this._ensureCursor();
-    return new Promise((resolve, reject) => {
-      this.queue.push({ query, resolve, reject });
-      this._drain();
+    const job = this._enqueue("search", SEARCH_PREFIX + query, {
+      timeoutMs: QUERY_TIMEOUT,
+      newChat: true,
+      execution: "fifo",
+      readOnly: true,
+      allowedPaths: []
     });
+    return job.promise;
+  }
+  async doTask(prompt, options = {}) {
+    const text = String(prompt || "").trim();
+    if (!text) throw new Error("prompt \u4E0D\u80FD\u4E3A\u7A7A");
+    if (text.length > 1e5) throw new Error("prompt \u8FC7\u957F\uFF08\u6700\u5927 100000 \u5B57\u7B26\uFF09");
+    await this._ensureCursor();
+    const execution = String(options.execution || "fifo");
+    if (execution !== "fifo" && execution !== "parallel_agent") {
+      throw new Error(`execution \u4E0D\u652F\u6301 ${execution}\uFF1B\u53EA\u80FD\u662F fifo \u6216 parallel_agent`);
+    }
+    const readOnly = options.readOnly === true;
+    const timeoutMs = Math.max(3e4, Math.min(9e5, Number(options.timeoutMs || 6e5)));
+    const allowedPaths = Array.isArray(options.allowedPaths) ? options.allowedPaths.map((x) => String(x).trim()).filter(Boolean) : [];
+    if (readOnly && allowedPaths.length > 0) {
+      throw new Error("read_only=true \u4E0E allowed_paths \u4E0D\u80FD\u540C\u65F6\u4F7F\u7528\uFF1B\u53EA\u8BFB\u4EFB\u52A1\u4E0D\u5F97\u58F0\u660E\u5199\u5165\u8303\u56F4");
+    }
+    if (execution === "parallel_agent" && !readOnly && allowedPaths.length === 0) {
+      throw new Error("parallel_agent \u5199\u4EFB\u52A1\u5FC5\u987B\u63D0\u4F9B allowed_paths\uFF1B\u7EAF\u8BFB\u53D6\u4EFB\u52A1\u8BF7\u663E\u5F0F\u8BBE\u7F6E read_only=true");
+    }
+    if (execution === "parallel_agent" && !readOnly) {
+      this._validateParallelAllowedPaths(allowedPaths);
+      this._assertNoParallelPathConflict(allowedPaths);
+    }
+    const contract = String(options.completionContract || "").trim();
+    let fullPrompt = text;
+    if (readOnly) fullPrompt += "\n\n\u53EA\u8BFB\u8FB9\u754C\uFF1A\u4E0D\u5F97\u4FEE\u6539\u3001\u521B\u5EFA\u6216\u5220\u9664\u4EFB\u4F55\u6587\u4EF6\uFF0C\u4E0D\u5F97\u6267\u884C\u4F1A\u6539\u53D8\u5DE5\u4F5C\u533A\u72B6\u6001\u7684\u547D\u4EE4\u3002";
+    if (allowedPaths.length > 0) {
+      fullPrompt += "\n\n\u5141\u8BB8\u4FEE\u6539\u8303\u56F4\uFF08\u4E0D\u5F97\u8D8A\u754C\uFF09\uFF1A\n" + allowedPaths.map((x) => "- " + x).join("\n");
+    }
+    fullPrompt += contract ? "\n\n\u9A8C\u6536\u4E0E\u56DE\u62A5\u5408\u540C\uFF1A\n" + contract : DO_DEFAULT_CONTRACT;
+    const job = this._enqueue("do", fullPrompt, {
+      timeoutMs,
+      newChat: execution === "parallel_agent" ? true : options.newChat !== false,
+      execution,
+      readOnly,
+      allowedPaths
+    });
+    if (options.background !== false) return this._taskView(job);
+    await job.promise;
+    return this._taskView(job, true);
+  }
+  _assertNoParallelPathConflict(allowedPaths) {
+    const live = [...this.tasks.values()].filter((job) => job.execution === "parallel_agent" && !job.readOnly && job.status !== "completed" && job.status !== "failed");
+    for (const job of live) {
+      const overlap = allowedPaths.some((a) => job.allowedPaths.some((b) => pathsOverlap(a, b)));
+      if (overlap) throw new Error(`parallel_agent allowed_paths \u4E0E\u4EFB\u52A1 ${job.id} \u91CD\u53E0\uFF1B\u8BF7\u6539\u7528 fifo \u6216\u62C6\u6210\u4E0D\u91CD\u53E0\u8DEF\u5F84`);
+    }
+  }
+  _validateParallelAllowedPaths(allowedPaths) {
+    for (const raw of allowedPaths) {
+      const slash = String(raw).replace(/\\/g, "/");
+      if (/[*?\[\]{}!]/.test(slash)) throw new Error(`parallel_agent allowed_paths \u4E0D\u63A5\u53D7 glob\uFF1A${raw}`);
+      if (/^[a-zA-Z]:\//.test(slash) || slash.startsWith("/")) {
+        throw new Error(`parallel_agent allowed_paths \u5FC5\u987B\u4F7F\u7528\u5DE5\u4F5C\u533A\u76F8\u5BF9\u8DEF\u5F84\uFF1A${raw}`);
+      }
+      const normalized = normalizeAllowedPath(slash);
+      if (normalized === "." || normalized === ".." || normalized.startsWith("../")) {
+        throw new Error(`parallel_agent allowed_paths \u4E0D\u5F97\u4E3A\u7A7A\u6216\u8D8A\u51FA\u5DE5\u4F5C\u533A\uFF1A${raw}`);
+      }
+    }
+  }
+  _enqueue(kind, prompt, options) {
+    const id = `cursor-${Date.now().toString(36)}-${this.nextTaskId++}`;
+    let resolvePromise;
+    let rejectPromise;
+    const promise = new Promise((resolve, reject) => {
+      resolvePromise = resolve;
+      rejectPromise = reject;
+    });
+    promise.catch(() => {
+    });
+    const job = {
+      id,
+      kind,
+      prompt,
+      timeoutMs: options.timeoutMs,
+      newChat: options.newChat,
+      execution: options.execution || "fifo",
+      effectiveExecution: options.execution || "fifo",
+      readOnly: options.readOnly === true,
+      allowedPaths: options.allowedPaths || [],
+      status: "queued",
+      phase: "queued",
+      createdAt: (/* @__PURE__ */ new Date()).toISOString(),
+      startedAt: null,
+      finishedAt: null,
+      sentAt: null,
+      agentId: null,
+      agentLabel: null,
+      fallbackReason: null,
+      result: null,
+      error: null,
+      settled: false,
+      promise,
+      resolve: resolvePromise,
+      reject: rejectPromise
+    };
+    this.tasks.set(id, job);
+    this.queue.push(job);
+    this._trimTasks();
+    this._drain();
+    return job;
+  }
+  _finishJob(job, result) {
+    if (job.settled) return;
+    job.result = result;
+    job.status = "completed";
+    job.phase = "completed";
+    job.finishedAt = (/* @__PURE__ */ new Date()).toISOString();
+    job.settled = true;
+    job.resolve(result);
+  }
+  _failJob(job, error2) {
+    if (job.settled) return;
+    const e = error2 instanceof Error ? error2 : new Error(String(error2));
+    job.error = e.message;
+    job.status = "failed";
+    job.phase = "failed";
+    job.finishedAt = (/* @__PURE__ */ new Date()).toISOString();
+    job.settled = true;
+    job.reject(e);
+  }
+  _orphanParallelJob(job, error2) {
+    const e = error2 instanceof Error ? error2 : new Error(String(error2));
+    job.error = e.message;
+    job.status = "needs_attention";
+    job.phase = "orphaned";
+    job.finishedAt = null;
+    this.activeParallel.set(job.id, job);
+    if (!job.settled) {
+      job.settled = true;
+      job.reject(e);
+    }
+  }
+  _withUiLock(fn) {
+    const run = this._uiTail.then(fn, fn);
+    this._uiTail = run.catch(() => {
+    });
+    return run;
+  }
+  _scheduleDrain(delay = 400) {
+    if (this._drainTimer) return;
+    this._drainTimer = setTimeout(() => {
+      this._drainTimer = null;
+      this._drain();
+    }, delay);
   }
   // 自愈：每次查询前委托 ensureCursorRunning。并发去重。失败静默降级（_run 报清晰错）。
   // 统一走 ensureCursorRunning 复用其【单一身份校验来源】（cdpUp + cdpIsCursor）——避免热路径裸 /json/version 检查
@@ -19486,104 +19723,473 @@ var CursorBridge = class {
   }
   async _drain() {
     if (this.busy || this.queue.length === 0) return;
+    if (this.queue[0].effectiveExecution !== "parallel_agent" && this.activeParallel.size > 0) {
+      this._scheduleDrain();
+      return;
+    }
     this.busy = true;
     const job = this.queue.shift();
+    job.status = "running";
+    job.startedAt = (/* @__PURE__ */ new Date()).toISOString();
     try {
-      job.resolve(await this._run(job.query));
+      if (job.effectiveExecution === "parallel_agent") {
+        job.phase = "submitting";
+        const submitted = await this._withUiLock(() => this._submitParallelAgent(job));
+        if (submitted.fallbackReason) {
+          job.effectiveExecution = "fifo";
+          job.fallbackReason = submitted.fallbackReason;
+          if (this.activeParallel.size > 0) {
+            job.status = "queued";
+            job.phase = "queued";
+            this.queue.unshift(job);
+            return;
+          }
+          job.phase = "running";
+          const result = await this._withUiLock(() => this._run(job.prompt, job));
+          this._finishJob(job, result);
+        } else {
+          job.agentId = submitted.agent.id;
+          job.agentLabel = submitted.agent.label || null;
+          job.sentAt = (/* @__PURE__ */ new Date()).toISOString();
+          job.phase = "running";
+          if (!this.parallelRestoreAgentId && submitted.previousSelectedId) {
+            this.parallelRestoreAgentId = submitted.previousSelectedId;
+          }
+          this.activeParallel.set(job.id, job);
+          this._monitorParallelAgent(job).catch((e) => this._failParallelJob(job, e));
+        }
+      } else {
+        job.phase = "running";
+        const result = await this._withUiLock(() => this._run(job.prompt, job));
+        this._finishJob(job, result);
+      }
     } catch (e) {
-      job.reject(e);
+      if (e && e.sent) {
+        job.error = `\u53D1\u9001\u72B6\u6001\u4E0D\u786E\u5B9A\uFF0C\u7EE7\u7EED\u6309 agentId \u76D1\u63A7\uFF1A${e.message}`;
+        if (job.agentId) {
+          job.phase = "running";
+          this.activeParallel.set(job.id, job);
+          this._monitorParallelAgent(job).catch((monitorError) => this._failParallelJob(job, monitorError));
+        } else {
+          this._orphanParallelJob(job, e);
+        }
+      } else {
+        this._failJob(job, e);
+      }
     } finally {
       this.busy = false;
       this._drain();
+      this._maybeRestoreParallelOrigin();
     }
   }
-  async _run(query) {
+  async _run(prompt, options = {}) {
     const page = await findPage();
     const c = makeClient(page.webSocketDebuggerUrl);
     await c.ready;
     try {
-      let vis = await evalJS(c, EXPR_VISIBLE);
-      if (!vis) {
-        await chord(c, 2, "L", "KeyL", 76);
-        await sleep(1300);
-        vis = await evalJS(c, EXPR_VISIBLE);
-      }
-      if (!vis) throw new Error("\u65E0\u6CD5\u6253\u5F00 Cursor chat \u9762\u677F\uFF08.aislash-editor-input \u4E0D\u53EF\u89C1\uFF09\u3002Cursor \u662F\u5426\u767B\u5F55\u4E14\u7A97\u53E3\u6B63\u5E38\uFF1F");
-      await this._newChat(c);
-      const filled = await evalJS(c, exprFill(SEARCH_PREFIX + query));
+      await this._ensureChatPanel(c);
+      if (options.newChat !== false) await this._newChat(c);
+      const filled = await evalJS(c, exprFill(prompt));
       if (filled === "NO_INPUT" || filled === "EXEC_FAIL") throw new Error("\u586B\u5165\u67E5\u8BE2\u5931\u8D25\uFF08\u8F93\u5165\u6846\u72B6\u6001\u5F02\u5E38\uFF09");
       await sleep(450);
+      let baseline = { messageCount: 0 };
+      try {
+        baseline = JSON.parse(await evalJS(c, EXPR_SNAP));
+      } catch {
+      }
       await chord(c, 0, "Enter", "Enter", 13);
-      return await this._waitComplete(c);
+      return await this._waitComplete(c, options.timeoutMs || QUERY_TIMEOUT, baseline.messageCount || 0);
     } finally {
       c.close();
     }
+  }
+  async _ensureChatPanel(c) {
+    let vis = await evalJS(c, EXPR_VISIBLE);
+    if (!vis) {
+      await chord(c, 2, "L", "KeyL", 76);
+      await sleep(1300);
+      vis = await evalJS(c, EXPR_VISIBLE);
+    }
+    if (!vis) throw new Error("\u65E0\u6CD5\u6253\u5F00 Cursor chat \u9762\u677F\uFF08.aislash-editor-input \u4E0D\u53EF\u89C1\uFF09\u3002Cursor \u662F\u5426\u767B\u5F55\u4E14\u7A97\u53E3\u6B63\u5E38\uFF1F");
   }
   // 清空对话上下文：定位 "New Agent" 钮后【Alt+click】——Alt 修饰使其执行 Replace Agent（清空旧对话），
   // 而非新建（aria 标注 "New Agent (Ctrl+N) / [Alt] Replace Agent"）。2026-06-08 实测回复区 markdown DOM 清空
   // 2719→17，避免 extract 串旧对话。找不到钮则跳过沿用当前（不阻断查询）。
   async _newChat(c) {
+    return this._clickNewAgent(c, true);
+  }
+  async _clickNewAgent(c, replaceCurrent) {
     try {
       const pos = await evalJS(c, EXPR_FIND_NEWAGENT);
       if (!pos) return false;
       const { x, y } = JSON.parse(pos);
-      await c.send("Input.dispatchMouseEvent", { type: "mousePressed", x, y, button: "left", clickCount: 1, modifiers: 1 });
-      await c.send("Input.dispatchMouseEvent", { type: "mouseReleased", x, y, button: "left", clickCount: 1, modifiers: 1 });
+      const modifiers = replaceCurrent ? 1 : 0;
+      await c.send("Input.dispatchMouseEvent", { type: "mousePressed", x, y, button: "left", clickCount: 1, modifiers });
+      await c.send("Input.dispatchMouseEvent", { type: "mouseReleased", x, y, button: "left", clickCount: 1, modifiers });
       await sleep(1100);
       return true;
     } catch {
       return false;
     }
   }
-  async _waitComplete(c) {
+  async _ensureHistoryOpen(c) {
+    if (await evalJS(c, EXPR_HISTORY_OPEN)) return true;
+    const pos = await evalJS(c, EXPR_FIND_HISTORY);
+    if (!pos) return false;
+    const { x, y } = JSON.parse(pos);
+    await c.send("Input.dispatchMouseEvent", { type: "mousePressed", x, y, button: "left", clickCount: 1 });
+    await c.send("Input.dispatchMouseEvent", { type: "mouseReleased", x, y, button: "left", clickCount: 1 });
+    await sleep(450);
+    return !!await evalJS(c, EXPR_HISTORY_OPEN);
+  }
+  async _closeHistory(c) {
+    try {
+      if (await evalJS(c, EXPR_HISTORY_OPEN)) {
+        await chord(c, 0, "Escape", "Escape", 27);
+        await sleep(180);
+      }
+    } catch {
+    }
+  }
+  async _readAgentEntries(c, keepOpen = false) {
+    if (!await this._ensureHistoryOpen(c)) throw new Error("Agent History \u83DC\u5355\u4E0D\u53EF\u7528");
+    try {
+      const snapshot = JSON.parse(await evalJS(c, EXPR_HISTORY_ENTRIES));
+      if (!snapshot.ok) throw new Error(snapshot.error || "Agent History React adapter \u4E0D\u53EF\u7528");
+      return snapshot.entries || [];
+    } finally {
+      if (!keepOpen) await this._closeHistory(c);
+    }
+  }
+  async _submitParallelAgent(job) {
+    const page = await findPage();
+    const c = makeClient(page.webSocketDebuggerUrl);
+    await c.ready;
+    let sent = false;
+    try {
+      await this._ensureChatPanel(c);
+      let before;
+      try {
+        before = await this._readAgentEntries(c);
+      } catch (e) {
+        return { fallbackReason: `parallel_agent \u524D\u7F6E\u80FD\u529B\u4E0D\u53EF\u7528\uFF1A${e.message}` };
+      }
+      const previousSelectedId = (before.find((e) => e.isSelected) || {}).id || null;
+      if (!await this._clickNewAgent(c, false)) {
+        return { fallbackReason: "\u627E\u4E0D\u5230 Cursor New Agent \u6309\u94AE\uFF0C\u5DF2\u5728\u53D1\u9001\u524D\u964D\u7EA7 FIFO" };
+      }
+      let agent = null;
+      for (let i = 0; i < 5 && !agent; i++) {
+        try {
+          agent = selectNewAgentEntry(before, await this._readAgentEntries(c));
+        } catch {
+        }
+        if (!agent) await sleep(350);
+      }
+      if (agent) {
+        job.agentId = agent.id;
+        job.agentLabel = agent.label || null;
+      }
+      await this._closeHistory(c);
+      await this._ensureChatPanel(c);
+      const filled = await evalJS(c, exprFill(job.prompt));
+      if (filled === "NO_INPUT" || filled === "EXEC_FAIL") throw new Error("parallel_agent \u586B\u5165\u4EFB\u52A1\u5931\u8D25");
+      await sleep(350);
+      sent = true;
+      await chord(c, 0, "Enter", "Enter", 13);
+      job.sentAt = (/* @__PURE__ */ new Date()).toISOString();
+      for (let i = 0; i < 12 && !agent; i++) {
+        await sleep(350);
+        try {
+          agent = selectNewAgentEntry(before, await this._readAgentEntries(c));
+        } catch {
+        }
+      }
+      if (!agent) {
+        const e = new Error("\u4EFB\u52A1\u53EF\u80FD\u5DF2\u53D1\u9001\uFF0C\u4F46\u65E0\u6CD5\u4ECE Agent History \u6355\u83B7\u552F\u4E00 agentId\uFF1B\u5DF2\u4FDD\u7559\u5360\u7528\uFF0C\u7981\u6B62\u81EA\u52A8\u91CD\u53D1");
+        e.sent = true;
+        throw e;
+      }
+      job.agentId = agent.id;
+      job.agentLabel = agent.label || null;
+      return { agent, previousSelectedId };
+    } catch (e) {
+      if (sent) e.sent = true;
+      throw e;
+    } finally {
+      await this._closeHistory(c);
+      c.close();
+    }
+  }
+  async _readParallelEntry(job) {
+    return this._withUiLock(async () => {
+      const page = await findPage();
+      const c = makeClient(page.webSocketDebuggerUrl);
+      await c.ready;
+      try {
+        const entries = await this._readAgentEntries(c);
+        return entries.find((e) => e.id === job.agentId) || null;
+      } finally {
+        c.close();
+      }
+    });
+  }
+  async _monitorParallelAgent(job) {
+    const started = Date.now();
+    let sawGenerating = false;
+    let completedStable = 0;
+    let missingPolls = 0;
+    let transientErrors = 0;
+    let collectionAttempts = 0;
+    let lastCollectionError = "";
+    while (Date.now() - started < job.timeoutMs) {
+      await sleep(1400);
+      let entry;
+      try {
+        entry = await this._readParallelEntry(job);
+        transientErrors = 0;
+      } catch (e) {
+        transientErrors++;
+        if (transientErrors >= 45) throw new Error(`\u8FDE\u7EED\u65E0\u6CD5\u8BFB\u53D6 Agent History\uFF1A${e.message}`);
+        continue;
+      }
+      if (!entry) {
+        missingPolls++;
+        if (missingPolls >= 45) throw new Error(`Agent History \u4E2D\u6301\u7EED\u4E22\u5931 ${job.agentId}`);
+        continue;
+      }
+      missingPolls = 0;
+      if (entry.showSpinner) {
+        sawGenerating = true;
+        completedStable = 0;
+        continue;
+      }
+      if (/error|failed|warning|circle-slash/i.test(entry.icon || "")) {
+        const e = new Error(`Cursor Agent ${job.agentId} \u663E\u793A\u5931\u8D25\u72B6\u6001 ${entry.icon}`);
+        e.confirmedTerminal = true;
+        throw e;
+      }
+      const completedIcon = /check-circled|check/i.test(entry.icon || "");
+      if (completedIcon) {
+        completedStable++;
+        if (sawGenerating || completedStable >= 2) {
+          job.phase = "collecting";
+          let result;
+          try {
+            result = await this._withUiLock(() => this._collectParallelAgent(job));
+          } catch (e) {
+            collectionAttempts++;
+            lastCollectionError = e.message;
+            job.error = `\u7B2C ${collectionAttempts} \u6B21\u56DE\u6536\u672A\u5B8C\u6210\uFF0C\u7EE7\u7EED\u91CD\u8BD5\uFF1A${e.message}`;
+            job.phase = "running";
+            completedStable = 0;
+            await sleep(1200);
+            continue;
+          }
+          job.error = null;
+          this.activeParallel.delete(job.id);
+          this._finishJob(job, result);
+          this._drain();
+          this._maybeRestoreParallelOrigin();
+          return;
+        }
+      } else {
+        completedStable = 0;
+      }
+    }
+    const detail = lastCollectionError ? `\uFF1B\u6700\u540E\u56DE\u6536\u9519\u8BEF\uFF1A${lastCollectionError}` : "";
+    throw new Error(`Cursor parallel_agent \u4EFB\u52A1\u8D85\u65F6 (${job.timeoutMs}ms)${detail}`);
+  }
+  async _waitForSelectedAgent(c, agentId, timeoutMs = 15e3) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const entries = await this._readAgentEntries(c);
+      const target = entries.find((e) => e.id === agentId);
+      if (target && target.isSelected) return true;
+      await sleep(250);
+    }
+    throw new Error(`\u6253\u5F00 ${agentId} \u540E\u672A\u786E\u8BA4\u5176\u6210\u4E3A\u5F53\u524D\u9009\u4E2D Agent`);
+  }
+  async _collectParallelAgent(job) {
+    const page = await findPage();
+    const c = makeClient(page.webSocketDebuggerUrl);
+    await c.ready;
+    let previousSelectedId = null;
+    try {
+      const entries = await this._readAgentEntries(c, true);
+      previousSelectedId = (entries.find((e) => e.isSelected) || {}).id || null;
+      const opened = await evalJS(c, exprOpenAgent(job.agentId));
+      if (opened !== "OPENED") throw new Error(`\u65E0\u6CD5\u6253\u5F00 ${job.agentId}: ${opened}`);
+      await this._closeHistory(c);
+      await this._waitForSelectedAgent(c, job.agentId);
+      let answer = "";
+      let lastKey = "";
+      let stable = 0;
+      for (let i = 0; i < 80; i++) {
+        let snap = { messageCount: 0, replyLength: 0, replyHash: 0 };
+        try {
+          snap = JSON.parse(await evalJS(c, EXPR_SNAP));
+        } catch {
+        }
+        const candidate = String(await evalJS(c, EXPR_EXTRACT) || "").trim();
+        if (candidate && Number(snap.stop || 0) === 0) {
+          const key = `${snap.replyLength}:${snap.replyHash}`;
+          if (key === lastKey) stable++;
+          else {
+            lastKey = key;
+            stable = 0;
+          }
+          if (stable >= 1) {
+            answer = candidate;
+            break;
+          }
+        }
+        await sleep(300);
+      }
+      if (!answer) throw new Error(`\u5DF2\u6253\u5F00 ${job.agentId}\uFF0C\u4F46\u672A\u627E\u5230\u52A9\u624B\u6700\u7EC8\u56DE\u590D`);
+      if (previousSelectedId && previousSelectedId !== job.agentId) {
+        if (await this._ensureHistoryOpen(c)) {
+          await evalJS(c, exprOpenAgent(previousSelectedId));
+          await this._closeHistory(c);
+          await this._waitForSelectedAgent(c, previousSelectedId);
+        }
+      }
+      return answer;
+    } finally {
+      await this._closeHistory(c);
+      c.close();
+    }
+  }
+  _failParallelJob(job, error2) {
+    if (error2 && error2.confirmedTerminal) {
+      this.activeParallel.delete(job.id);
+      this._failJob(job, error2);
+      this._drain();
+      this._maybeRestoreParallelOrigin();
+      return;
+    }
+    this._orphanParallelJob(job, error2);
+  }
+  _maybeRestoreParallelOrigin() {
+    if (!this.parallelRestoreAgentId || this.busy || this.activeParallel.size > 0 || this.queue.some((job) => job.execution === "parallel_agent")) return;
+    const agentId = this.parallelRestoreAgentId;
+    this.parallelRestoreAgentId = null;
+    this._withUiLock(async () => {
+      const page = await findPage();
+      const c = makeClient(page.webSocketDebuggerUrl);
+      await c.ready;
+      try {
+        if (await this._ensureHistoryOpen(c)) {
+          await evalJS(c, exprOpenAgent(agentId));
+          await sleep(450);
+        }
+      } finally {
+        await this._closeHistory(c);
+        c.close();
+      }
+    }).catch((e) => console.error("\u26A0\uFE0F \u6062\u590D\u539F Cursor Agent \u5931\u8D25\uFF1A" + e.message));
+  }
+  async _waitComplete(c, timeoutMs = QUERY_TIMEOUT, baselineCount = 0) {
     const start = Date.now();
     const INTERVAL = 1e3;
     let sawStop = false;
-    let lastMd = 0, stableMd = 0;
+    let lastReplyKey = "", stableReply = 0;
     await sleep(1200);
-    while (Date.now() - start < QUERY_TIMEOUT) {
+    while (Date.now() - start < timeoutMs) {
       let s;
       try {
         s = JSON.parse(await evalJS(c, EXPR_SNAP));
       } catch {
-        s = { stop: 0, mdMax: 0 };
+        s = { stop: 0, messageCount: 0, replyLength: 0, replyHash: 0 };
       }
       if (s.stop > 0) sawStop = true;
-      if (sawStop && s.stop === 0 && s.mdMax > 40) {
+      if (sawStop && s.stop === 0 && s.replyLength > 0) {
         await sleep(800);
         const ans2 = await evalJS(c, EXPR_EXTRACT);
-        if (ans2 && ans2.length > 0) return ans2;
+        if (ans2) return ans2;
       }
-      if (!sawStop && s.mdMax > 80) {
-        if (s.mdMax === lastMd) {
-          stableMd++;
-          if (stableMd >= 6) {
+      if (!sawStop && s.messageCount >= baselineCount + 2 && s.replyLength > 0) {
+        const key = `${s.replyLength}:${s.replyHash}`;
+        if (key === lastReplyKey) {
+          stableReply++;
+          if (stableReply >= 4) {
             const ans2 = await evalJS(c, EXPR_EXTRACT);
             if (ans2) return ans2;
           }
         } else {
-          stableMd = 0;
-          lastMd = s.mdMax;
+          stableReply = 0;
+          lastReplyKey = key;
         }
       }
       await sleep(INTERVAL);
     }
+    let finalSnap = { messageCount: 0 };
+    try {
+      finalSnap = JSON.parse(await evalJS(c, EXPR_SNAP));
+    } catch {
+    }
     const ans = await evalJS(c, EXPR_EXTRACT);
-    if (ans && ans.length > 40) return ans;
-    throw new Error(`Cursor \u67E5\u8BE2\u8D85\u65F6 (${QUERY_TIMEOUT}ms) \u672A\u4EA7\u751F\u5B9E\u8D28\u56DE\u590D`);
+    if (ans && (sawStop || finalSnap.messageCount >= baselineCount + 2)) return ans;
+    throw new Error(`Cursor \u4EFB\u52A1\u8D85\u65F6 (${timeoutMs}ms) \u672A\u4EA7\u751F\u53EF\u786E\u8BA4\u7684\u52A9\u624B\u56DE\u590D`);
   }
-  async status() {
+  _taskView(job, includeResult = false) {
+    const view = {
+      taskId: job.id,
+      kind: job.kind,
+      status: job.status,
+      phase: job.phase,
+      execution: job.execution,
+      effectiveExecution: job.effectiveExecution,
+      readOnly: job.readOnly,
+      allowedPaths: job.allowedPaths,
+      agentId: job.agentId,
+      agentLabel: job.agentLabel,
+      fallbackReason: job.fallbackReason,
+      createdAt: job.createdAt,
+      startedAt: job.startedAt,
+      sentAt: job.sentAt,
+      finishedAt: job.finishedAt,
+      error: job.error
+    };
+    if (includeResult || job.status === "completed" || job.status === "failed") view.result = job.result;
+    return view;
+  }
+  _trimTasks() {
+    if (this.tasks.size <= 50) return;
+    for (const [id, job] of this.tasks) {
+      if (job.status === "completed" || job.status === "failed") this.tasks.delete(id);
+      if (this.tasks.size <= 50) break;
+    }
+  }
+  async status(taskId = "") {
+    if (taskId) {
+      const job = this.tasks.get(String(taskId));
+      if (!job) return { found: false, taskId: String(taskId) };
+      return { found: true, ...this._taskView(job, true) };
+    }
+    const parallelRunning = this.activeParallel.size;
+    const uiBusy = this.busy;
+    const common = {
+      busy: uiBusy || parallelRunning > 0 || this.queue.length > 0,
+      uiBusy,
+      parallelRunning,
+      idle: !uiBusy && parallelRunning === 0 && this.queue.length === 0,
+      queued: this.queue.length,
+      activeParallel: [...this.activeParallel.values()].map((job) => this._taskView(job)),
+      recentTasks: [...this.tasks.values()].slice(-10).map((job) => this._taskView(job)),
+      cdpPort: CDP_PORT2
+    };
     try {
       const ver = await httpJson("/json/version");
       const page = await findPage();
-      return { connected: true, busy: this.busy, queued: this.queue.length, cdpPort: CDP_PORT2, browser: ver.Browser, page: (page.url || "").slice(0, 60) };
+      return { connected: true, ...common, browser: ver.Browser, page: (page.url || "").slice(0, 60) };
     } catch (e) {
-      return { connected: false, busy: this.busy, queued: this.queue.length, cdpPort: CDP_PORT2, error: e.message };
+      return { connected: false, ...common, error: e.message };
     }
   }
 };
 var bridge = new CursorBridge();
-var server = new Server({ name: "cursor-bridge", version: "1.0.0" }, { capabilities: { tools: {} } });
+var server = new Server({ name: "cursor-bridge", version: "2.0.7" }, { capabilities: { tools: {} } });
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [
     {
@@ -19598,9 +20204,27 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       }
     },
     {
+      name: "cursor_do",
+      description: "\u628A\u8FB9\u754C\u660E\u786E\u7684\u4EFB\u52A1\u4EA4\u7ED9 Cursor agent \u6267\u884C\u3002\u9ED8\u8BA4 execution=fifo \u540E\u53F0\u6392\u961F\uFF1Bexecution=parallel_agent \u4F1A\u4E32\u884C\u64CD\u63A7 UI \u63D0\u4EA4\u5230\u72EC\u7ACB\u9876\u5C42 Agent\uFF0C\u518D\u6309\u7A33\u5B9A agentId \u5E76\u884C\u8DDF\u8E2A\u548C\u9010\u9879\u6536\u56DE\u3002\u5E76\u884C\u5199\u4EFB\u52A1\u5FC5\u987B\u63D0\u4F9B\u4E0D\u91CD\u53E0\u7684 allowed_paths\uFF1B\u53EA\u8BFB\u4EFB\u52A1\u5E94\u8BBE\u7F6E read_only=true\u3002\u7528 cursor_status(task_id) \u67E5\u8BE2\u72B6\u6001\u548C\u539F\u59CB\u56DE\u590D\u3002Cursor \u7ED3\u679C\u4E0D\u662F\u6B63\u5F0F\u9A8C\u8BC1\uFF0C\u4E3B Agent \u4ECD\u9700\u68C0\u67E5\u771F\u5B9E\u6539\u52A8\u3002",
+      inputSchema: {
+        type: "object",
+        properties: {
+          prompt: { type: "string", description: "\u539F\u6837\u4EA4\u7ED9 Cursor \u7684\u4EFB\u52A1\u5185\u5BB9\uFF0C\u5FC5\u987B\u5305\u542B\u660E\u786E\u76EE\u6807\u3001\u8FB9\u754C\u548C\u5B8C\u6210\u5408\u540C" },
+          background: { type: "boolean", default: true, description: "\u9ED8\u8BA4 true\uFF1A\u7ACB\u5373\u8FD4\u56DE taskId\uFF1Bfalse\uFF1A\u7B49\u5F85\u8BE5\u4EFB\u52A1\u8FDB\u5165\u7EC8\u6001" },
+          execution: { type: "string", enum: ["fifo", "parallel_agent"], default: "fifo", description: "fifo \u4FDD\u6301\u5355\u5BF9\u8BDD\u4E32\u884C\uFF1Bparallel_agent \u4F7F\u7528\u72EC\u7ACB\u9876\u5C42 Agent \u5E76\u884C\u8FD0\u884C" },
+          read_only: { type: "boolean", default: false, description: "\u663E\u5F0F\u58F0\u660E\u4EFB\u52A1\u4E0D\u5F97\u4FEE\u6539\u5DE5\u4F5C\u533A\uFF1Bparallel_agent \u53EA\u8BFB\u4EFB\u52A1\u5E94\u8BBE true" },
+          new_chat: { type: "boolean", default: true, description: "fifo \u662F\u5426\u4F7F\u7528\u5E72\u51C0\u5BF9\u8BDD\uFF1Bparallel_agent \u59CB\u7EC8\u5F3A\u5236\u72EC\u7ACB New Agent" },
+          timeout_ms: { type: "integer", minimum: 3e4, maximum: 9e5, default: 6e5, description: "\u5355\u4EFB\u52A1\u8D85\u65F6\uFF0C\u9ED8\u8BA4 10 \u5206\u949F" },
+          allowed_paths: { type: "array", items: { type: "string" }, description: "\u5DE5\u4F5C\u533A\u76F8\u5BF9\u8DEF\u5F84\u7684\u5199\u5165\u8303\u56F4\u58F0\u660E\uFF1B\u5E76\u884C\u5199\u4EFB\u52A1\u5FC5\u586B\u3001\u4E0D\u5F97\u542B glob/\u8D8A\u754C\uFF0C\u4E14\u4E0D\u5F97\u4E0E\u6D3B\u52A8\u5E76\u884C\u4EFB\u52A1\u91CD\u53E0\u3002\u5B83\u4E0D\u662F\u6587\u4EF6\u7CFB\u7EDF\u6C99\u7BB1" },
+          completion_contract: { type: "string", description: "\u53EF\u9009\uFF1A\u81EA\u5B9A\u4E49\u9A8C\u6536\u548C\u6700\u7EC8\u56DE\u62A5\u683C\u5F0F" }
+        },
+        required: ["prompt"]
+      }
+    },
+    {
       name: "cursor_status",
-      description: "\u68C0\u67E5 cursor-bridge \u4E0E Cursor CDP\uFF089223\uFF09\u7684\u8FDE\u63A5/\u961F\u5217\u72B6\u6001\u3002",
-      inputSchema: { type: "object", properties: {} }
+      description: "\u68C0\u67E5 Cursor CDP\u3001FIFO \u961F\u5217\u548C\u6D3B\u52A8\u5E76\u884C Agent\uFF1B\u4F20 task_id \u53EF\u7CBE\u786E\u67E5\u8BE2 cursor_do \u7684 agentId\u3001\u9636\u6BB5\u4E0E\u7ED3\u679C\u3002",
+      inputSchema: { type: "object", properties: { task_id: { type: "string", description: "\u53EF\u9009\uFF1Acursor_do \u8FD4\u56DE\u7684 taskId" } } }
     },
     {
       name: "cursor_launch",
@@ -19616,8 +20240,20 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const result = await bridge.search(String(args && args.query || ""));
       return { content: [{ type: "text", text: String(result) }] };
     }
+    if (name === "cursor_do") {
+      const result = await bridge.doTask(String(args && args.prompt || ""), {
+        background: !args || args.background !== false,
+        execution: args && args.execution,
+        readOnly: !!(args && args.read_only),
+        newChat: !args || args.new_chat !== false,
+        timeoutMs: args && args.timeout_ms,
+        allowedPaths: args && args.allowed_paths,
+        completionContract: args && args.completion_contract
+      });
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    }
     if (name === "cursor_status") {
-      return { content: [{ type: "text", text: JSON.stringify(await bridge.status(), null, 2) }] };
+      return { content: [{ type: "text", text: JSON.stringify(await bridge.status(args && args.task_id), null, 2) }] };
     }
     if (name === "cursor_launch") {
       const { ensureCursorRunning: ensureCursorRunning2 } = await Promise.resolve().then(() => (init_launch_cursor(), launch_cursor_exports));
@@ -19656,5 +20292,8 @@ if (isMain2) {
 }
 export {
   CursorBridge,
-  bridge
+  bridge,
+  normalizeAllowedPath,
+  pathsOverlap,
+  selectNewAgentEntry
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cursor-mcp-bridge",
-  "version": "2.0.7",
-  "description": "MCP server: drive Cursor IDE's agent for semantic code search from Claude Code over CDP. Distributed as a Claude Code plugin. CDP direct-drive, no console injection.",
+  "version": "2.1.0",
+  "description": "MCP server for Cursor semantic search and bounded delegated execution over CDP, with FIFO and safe top-level Agent parallel modes.",
   "type": "module",
   "main": "server.mjs",
   "engines": {
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "start": "node server.mjs",
-    "build": "node build.mjs"
+    "build": "node build.mjs",
+    "test": "node --test test/*.test.mjs"
   },
   "keywords": [
     "mcp",

--- a/server.mjs
+++ b/server.mjs
@@ -2,14 +2,14 @@
 /**
  * cursor-bridge — MCP server（CDP 直驱架构）
  *
- * 让 Claude Code 调 Cursor IDE 里的 agent 检索（语义搜索 + Instant Grep，agent 自动编排）。
+ * 让 Codex 调 Cursor IDE 里的 agent 做语义检索与边界明确的委托执行。
  * Cursor 的语义搜索【没有纯检索接口/独立 UI】（2026-06-08 CDP 实测：
  *   window.vscode 是 sandbox preload 无 command API；Ctrl+Shift+F 是普通全文搜索），
  *   只能跑 agent 拿（用户拍板 B1）。故走 @Codebase/agent chat：填查询 → Enter → 等完成 → 抓回复。
  *
  * 架构（CDP 直驱，无需 console+WS 回连）：
  *   Claude Code --(MCP stdio)--> 本 server --(CDP 9223 Runtime.evaluate + Input)--> Cursor 渲染进程
- *   server 每次查询新建 CDP 连接（串行，GUI 单输入框），直接驱动 DOM + 真实键盘。
+ *   GUI 操作通过互斥锁串行；独立顶层 Cursor Agent 在提交后可并行运行，再按 agentId 逐项取回。
  *
  * 实测确认的链路（2026-06-08，见 .claude/scripts/cursor-bridge/probe-*.mjs）：
  *   - 输入框 `.aislash-editor-input`（lexical contenteditable）；Ctrl+L 开/关 chat（toggle）。
@@ -34,6 +34,10 @@ const QUERY_TIMEOUT = Number(process.env.CURSOR_BRIDGE_TIMEOUT || 180000);
 const SEARCH_PREFIX =
   '只做代码检索定位：列出与下面意图相关的文件路径 + 行号范围（形如 Assets/Scripts/X.cs:120-180），' +
   '逐行列出即可。不要读取文件正文、不要修改任何代码、不要展开长篇解释。\n\n意图：';
+
+const DO_DEFAULT_CONTRACT =
+  '\n\n完成要求：在当前 Cursor 已打开的工作区内直接完成任务；不要推送远端。' +
+  '结束前检查实际改动并运行与风险匹配的验证。最终回复必须列出：完成内容、改动文件、验证结果、仍有风险或阻塞。';
 
 // ---------- CDP helpers ----------
 // 连接目标用字面 IP '127.0.0.1'，不用 'localhost'：Windows 上 "localhost" DNS 常优先解析到 ::1，
@@ -97,28 +101,295 @@ function exprFill(text) {
   const js = JSON.stringify(text);
   return `(function(){const inp=document.querySelector('.aislash-editor-input');if(!inp||inp.offsetParent===null)return 'NO_INPUT';inp.focus();try{const s=getSelection();const r=document.createRange();r.selectNodeContents(inp);s.removeAllRanges();s.addRange(r);}catch(e){}const ok=document.execCommand('insertText',false,${js});inp.dispatchEvent(new Event('input',{bubbles:true}));return ok?(inp.innerText||'').slice(0,30):'EXEC_FAIL';})()`;
 }
-// 生成中/完成信号：stop 钮（codicon-stop/debug-stop/aria含Stop）数 + 最长 markdown 长度
+// 生成中/完成信号：stop 钮数量 + 当前会话中最后一个真实消息 markdown。
+// 排除模型选择器里的 markdown，避免短回复被 "Cursor Grok ..." 等模型标签盖过。
 const EXPR_SNAP = `(function(){
-  const md=[...document.querySelectorAll('.markdown-root,.aichat-container [class*=markdown]')];
-  let mdMax=0; for(const m of md){const t=(m.innerText||'').length; if(t>mdMax)mdMax=t;}
+  const md=[...document.querySelectorAll('.markdown-root,.aichat-container [class*=markdown]')]
+    .filter(e=>e.offsetParent!==null&&!e.closest('.ui-model-picker__trigger,[class*=model-picker]'));
+  const texts=md.map(m=>(m.innerText||'').trim()).filter(Boolean);
+  const last=texts[texts.length-1]||'';
+  let hash=0; for(let i=0;i<last.length;i++)hash=((hash<<5)-hash+last.charCodeAt(i))|0;
   const stop=[...document.querySelectorAll('[class*=codicon-stop],[class*=debug-stop],[aria-label*=Stop],[aria-label*=stop],[aria-label*=Cancel],[title*=Stop]')].filter(e=>e.offsetParent!==null).length;
-  return JSON.stringify({mdMax, stop});
+  return JSON.stringify({messageCount:texts.length,replyLength:last.length,replyHash:hash,stop});
 })()`;
-// 抓答案：最长 markdown-root 的纯文本
+// 抓答案：最后一个可见且不属于模型选择器的 markdown；短回复同样有效。
 const EXPR_EXTRACT = `(function(){
-  const md=[...document.querySelectorAll('.markdown-root,.aichat-container [class*=markdown]')].filter(e=>e.offsetParent!==null);
-  let best=''; for(const m of md){const t=(m.innerText||'').trim(); if(t.length>best.length)best=t;}
-  return best;
+  const md=[...document.querySelectorAll('.markdown-root,.aichat-container [class*=markdown]')]
+    .filter(e=>e.offsetParent!==null&&!e.closest('.ui-model-picker__trigger,[class*=model-picker]'));
+  const texts=md.map(m=>(m.innerText||'').trim()).filter(Boolean);
+  return texts[texts.length-1]||'';
 })()`;
 // "New Agent" 新对话钮中心坐标（aria-label 含 New Agent/New Chat）；返回 JSON 坐标或空串。
 const EXPR_FIND_NEWAGENT = `(function(){const b=[...document.querySelectorAll('button,[role=button],a.action-label,.codicon')].find(e=>e.offsetParent!==null&&/New Agent|New Chat/i.test(e.getAttribute('aria-label')||''));if(!b)return '';const r=b.getBoundingClientRect();return JSON.stringify({x:Math.round(r.x+r.width/2),y:Math.round(r.y+r.height/2)});})()`;
 
+const EXPR_HISTORY_OPEN = `(function(){return !![...document.querySelectorAll('.compact-agent-history-react-menu-label')].find(e=>e.offsetParent!==null);})()`;
+const EXPR_FIND_HISTORY = `(function(){const b=[...document.querySelectorAll('button,[role=button],a.action-label,.codicon')].find(e=>{if(e.offsetParent===null)return false;const s=(e.getAttribute('aria-label')||'')+' '+(e.getAttribute('title')||'');return /Show Chat History|Chat History|Agent History/i.test(s);});if(!b)return '';const r=b.getBoundingClientRect();return JSON.stringify({x:Math.round(r.x+r.width/2),y:Math.round(r.y+r.height/2)});})()`;
+
+// Cursor 3.7 的 Agent History 菜单由 React 提供 entries + onOpenEntry(id)。
+// 内部接口集中封装在这里；探测失败时只允许在发送前降级 FIFO，绝不重复提交已发送任务。
+const REACT_ADAPTER_BODY = `
+  const findAdapter=()=>{
+    const label=[...document.querySelectorAll('.compact-agent-history-react-menu-label')].find(e=>e.offsetParent!==null);
+    if(!label)return null;
+    const nodes=[]; let n=label;
+    for(let i=0;n&&i<18;i++,n=n.parentElement)nodes.push(n);
+    for(const node of nodes){
+      for(const key of Object.keys(node)){
+        if(!key.startsWith('__reactFiber$')&&!key.startsWith('__reactProps$'))continue;
+        const seed=node[key];
+        let f=key.startsWith('__reactFiber$')?seed:{memoizedProps:seed,return:null};
+        for(let j=0;f&&j<36;j++,f=f.return){
+          for(const p of [f.memoizedProps,f.pendingProps,f.stateNode&&f.stateNode.props]){
+            if(p&&Array.isArray(p.entries)&&typeof p.onOpenEntry==='function')return {props:p};
+          }
+        }
+      }
+    }
+    return null;
+  };
+  const a=findAdapter();`;
+
+const EXPR_HISTORY_ENTRIES = `(function(){${REACT_ADAPTER_BODY}
+  if(!a)return JSON.stringify({ok:false,error:'REACT_ADAPTER_UNAVAILABLE'});
+  const entries=a.props.entries.map((e,index)=>{
+    const raw=e.timestamp;
+    let timestamp=raw instanceof Date?raw.getTime():Number(raw);
+    if(!Number.isFinite(timestamp))timestamp=Date.parse(String(raw||''));
+    if(!Number.isFinite(timestamp))timestamp=index;
+    return {
+      id:String(e.id||''),label:String(e.label||''),searchText:String(e.searchText||''),timestamp,
+      isSelected:!!e.isSelected,showSpinner:!!e.showSpinner,
+      icon:String(typeof e.icon==='string'?e.icon:(e.icon&&((e.icon.id)||(e.icon.props&&e.icon.props.id)||(e.icon.type&&e.icon.type.id)))||'')
+    };
+  }).filter(e=>e.id);
+  return JSON.stringify({ok:true,entries});
+})()`;
+
+function exprOpenAgent(agentId) {
+  const id = JSON.stringify(String(agentId));
+  return `(function(){${REACT_ADAPTER_BODY}
+    if(!a)return 'REACT_ADAPTER_UNAVAILABLE';
+    const e=a.props.entries.find(x=>String(x.id||'')===${id}); if(!e)return 'AGENT_NOT_FOUND';
+    a.props.onOpenEntry(${id}); return 'OPENED';
+  })()`;
+}
+
+function normalizeAllowedPath(value) {
+  const raw = String(value || '').trim().replace(/\\/g, '/');
+  const prefix = /^[a-zA-Z]:/.test(raw) ? raw.slice(0, 2).toLowerCase() : '';
+  const body = prefix ? raw.slice(2) : raw;
+  const parts = [];
+  for (const part of body.split('/')) {
+    if (!part || part === '.') continue;
+    if (part === '..') {
+      if (parts.length > 0 && parts[parts.length - 1] !== '..') parts.pop();
+      else parts.push('..');
+    } else {
+      parts.push(part.toLowerCase());
+    }
+  }
+  const normalized = (prefix ? prefix + '/' : '') + parts.join('/');
+  return normalized || '.';
+}
+
+function pathsOverlap(a, b) {
+  const left = normalizeAllowedPath(a);
+  const right = normalizeAllowedPath(b);
+  return left === '.' || right === '.' || left === right || left.startsWith(right + '/') || right.startsWith(left + '/');
+}
+
+function selectNewAgentEntry(beforeEntries, afterEntries) {
+  const before = new Set((beforeEntries || []).map((e) => e.id));
+  const fresh = (afterEntries || []).map((e, index) => ({ ...e, _index: index })).filter((e) => e.id && !before.has(e.id));
+  if (fresh.length === 0) return null;
+  const selected = fresh.filter((e) => e.isSelected);
+  const pool = selected.length > 0 ? selected : fresh;
+  return [...pool].sort((a, b) => (Number(b.timestamp || 0) - Number(a.timestamp || 0)) || b._index - a._index)[0];
+}
+
 class CursorBridge {
-  constructor() { this.busy = false; this.queue = []; this._healing = null; }
+  constructor() {
+    this.busy = false;
+    this.queue = [];
+    this._healing = null;
+    this.tasks = new Map();
+    this.nextTaskId = 1;
+    this.activeParallel = new Map();
+    this._uiTail = Promise.resolve();
+    this._drainTimer = null;
+    this.parallelRestoreAgentId = null;
+  }
 
   async search(query) {
     await this._ensureCursor();
-    return new Promise((resolve, reject) => { this.queue.push({ query, resolve, reject }); this._drain(); });
+    const job = this._enqueue('search', SEARCH_PREFIX + query, {
+      timeoutMs: QUERY_TIMEOUT,
+      newChat: true,
+      execution: 'fifo',
+      readOnly: true,
+      allowedPaths: [],
+    });
+    return job.promise;
+  }
+
+  async doTask(prompt, options = {}) {
+    const text = String(prompt || '').trim();
+    if (!text) throw new Error('prompt 不能为空');
+    if (text.length > 100000) throw new Error('prompt 过长（最大 100000 字符）');
+    await this._ensureCursor();
+
+    const execution = String(options.execution || 'fifo');
+    if (execution !== 'fifo' && execution !== 'parallel_agent') {
+      throw new Error(`execution 不支持 ${execution}；只能是 fifo 或 parallel_agent`);
+    }
+    const readOnly = options.readOnly === true;
+    const timeoutMs = Math.max(30000, Math.min(900000, Number(options.timeoutMs || 600000)));
+    const allowedPaths = Array.isArray(options.allowedPaths)
+      ? options.allowedPaths.map((x) => String(x).trim()).filter(Boolean)
+      : [];
+    if (readOnly && allowedPaths.length > 0) {
+      throw new Error('read_only=true 与 allowed_paths 不能同时使用；只读任务不得声明写入范围');
+    }
+    if (execution === 'parallel_agent' && !readOnly && allowedPaths.length === 0) {
+      throw new Error('parallel_agent 写任务必须提供 allowed_paths；纯读取任务请显式设置 read_only=true');
+    }
+    if (execution === 'parallel_agent' && !readOnly) {
+      this._validateParallelAllowedPaths(allowedPaths);
+      this._assertNoParallelPathConflict(allowedPaths);
+    }
+
+    const contract = String(options.completionContract || '').trim();
+    let fullPrompt = text;
+    if (readOnly) fullPrompt += '\n\n只读边界：不得修改、创建或删除任何文件，不得执行会改变工作区状态的命令。';
+    if (allowedPaths.length > 0) {
+      fullPrompt += '\n\n允许修改范围（不得越界）：\n' + allowedPaths.map((x) => '- ' + x).join('\n');
+    }
+    fullPrompt += contract ? '\n\n验收与回报合同：\n' + contract : DO_DEFAULT_CONTRACT;
+
+    const job = this._enqueue('do', fullPrompt, {
+      timeoutMs,
+      newChat: execution === 'parallel_agent' ? true : options.newChat !== false,
+      execution,
+      readOnly,
+      allowedPaths,
+    });
+    if (options.background !== false) return this._taskView(job);
+    await job.promise;
+    return this._taskView(job, true);
+  }
+
+  _assertNoParallelPathConflict(allowedPaths) {
+    const live = [...this.tasks.values()].filter((job) =>
+      job.execution === 'parallel_agent' && !job.readOnly && job.status !== 'completed' && job.status !== 'failed');
+    for (const job of live) {
+      const overlap = allowedPaths.some((a) => job.allowedPaths.some((b) => pathsOverlap(a, b)));
+      if (overlap) throw new Error(`parallel_agent allowed_paths 与任务 ${job.id} 重叠；请改用 fifo 或拆成不重叠路径`);
+    }
+  }
+
+  _validateParallelAllowedPaths(allowedPaths) {
+    for (const raw of allowedPaths) {
+      const slash = String(raw).replace(/\\/g, '/');
+      if (/[*?\[\]{}!]/.test(slash)) throw new Error(`parallel_agent allowed_paths 不接受 glob：${raw}`);
+      if (/^[a-zA-Z]:\//.test(slash) || slash.startsWith('/')) {
+        throw new Error(`parallel_agent allowed_paths 必须使用工作区相对路径：${raw}`);
+      }
+      const normalized = normalizeAllowedPath(slash);
+      if (normalized === '.' || normalized === '..' || normalized.startsWith('../')) {
+        throw new Error(`parallel_agent allowed_paths 不得为空或越出工作区：${raw}`);
+      }
+    }
+  }
+
+  _enqueue(kind, prompt, options) {
+    const id = `cursor-${Date.now().toString(36)}-${this.nextTaskId++}`;
+    let resolvePromise;
+    let rejectPromise;
+    const promise = new Promise((resolve, reject) => {
+      resolvePromise = resolve;
+      rejectPromise = reject;
+    });
+    promise.catch(() => {});
+    const job = {
+      id,
+      kind,
+      prompt,
+      timeoutMs: options.timeoutMs,
+      newChat: options.newChat,
+      execution: options.execution || 'fifo',
+      effectiveExecution: options.execution || 'fifo',
+      readOnly: options.readOnly === true,
+      allowedPaths: options.allowedPaths || [],
+      status: 'queued',
+      phase: 'queued',
+      createdAt: new Date().toISOString(),
+      startedAt: null,
+      finishedAt: null,
+      sentAt: null,
+      agentId: null,
+      agentLabel: null,
+      fallbackReason: null,
+      result: null,
+      error: null,
+      settled: false,
+      promise,
+      resolve: resolvePromise,
+      reject: rejectPromise,
+    };
+    this.tasks.set(id, job);
+    this.queue.push(job);
+    this._trimTasks();
+    this._drain();
+    return job;
+  }
+
+  _finishJob(job, result) {
+    if (job.settled) return;
+    job.result = result;
+    job.status = 'completed';
+    job.phase = 'completed';
+    job.finishedAt = new Date().toISOString();
+    job.settled = true;
+    job.resolve(result);
+  }
+
+  _failJob(job, error) {
+    if (job.settled) return;
+    const e = error instanceof Error ? error : new Error(String(error));
+    job.error = e.message;
+    job.status = 'failed';
+    job.phase = 'failed';
+    job.finishedAt = new Date().toISOString();
+    job.settled = true;
+    job.reject(e);
+  }
+
+  _orphanParallelJob(job, error) {
+    const e = error instanceof Error ? error : new Error(String(error));
+    job.error = e.message;
+    job.status = 'needs_attention';
+    job.phase = 'orphaned';
+    job.finishedAt = null;
+    // 保留在 activeParallel：真实 Cursor Agent 可能仍在运行，继续占用 allowed_paths 并阻止 FIFO。
+    this.activeParallel.set(job.id, job);
+    if (!job.settled) {
+      job.settled = true;
+      job.reject(e);
+    }
+  }
+
+  _withUiLock(fn) {
+    const run = this._uiTail.then(fn, fn);
+    this._uiTail = run.catch(() => {});
+    return run;
+  }
+
+  _scheduleDrain(delay = 400) {
+    if (this._drainTimer) return;
+    this._drainTimer = setTimeout(() => {
+      this._drainTimer = null;
+      this._drain();
+    }, delay);
   }
 
   // 自愈：每次查询前委托 ensureCursorRunning。并发去重。失败静默降级（_run 报清晰错）。
@@ -140,92 +411,484 @@ class CursorBridge {
   }
   async _drain() {
     if (this.busy || this.queue.length === 0) return;
+    if (this.queue[0].effectiveExecution !== 'parallel_agent' && this.activeParallel.size > 0) {
+      this._scheduleDrain();
+      return;
+    }
     this.busy = true;
     const job = this.queue.shift();
-    try { job.resolve(await this._run(job.query)); }
-    catch (e) { job.reject(e); }
-    finally { this.busy = false; this._drain(); }
+    job.status = 'running';
+    job.startedAt = new Date().toISOString();
+    try {
+      if (job.effectiveExecution === 'parallel_agent') {
+        job.phase = 'submitting';
+        const submitted = await this._withUiLock(() => this._submitParallelAgent(job));
+        if (submitted.fallbackReason) {
+          job.effectiveExecution = 'fifo';
+          job.fallbackReason = submitted.fallbackReason;
+          if (this.activeParallel.size > 0) {
+            job.status = 'queued';
+            job.phase = 'queued';
+            this.queue.unshift(job);
+            return;
+          }
+          job.phase = 'running';
+          const result = await this._withUiLock(() => this._run(job.prompt, job));
+          this._finishJob(job, result);
+        } else {
+          job.agentId = submitted.agent.id;
+          job.agentLabel = submitted.agent.label || null;
+          job.sentAt = new Date().toISOString();
+          job.phase = 'running';
+          if (!this.parallelRestoreAgentId && submitted.previousSelectedId) {
+            this.parallelRestoreAgentId = submitted.previousSelectedId;
+          }
+          this.activeParallel.set(job.id, job);
+          this._monitorParallelAgent(job).catch((e) => this._failParallelJob(job, e));
+        }
+      } else {
+        job.phase = 'running';
+        const result = await this._withUiLock(() => this._run(job.prompt, job));
+        this._finishJob(job, result);
+      }
+    } catch (e) {
+      if (e && e.sent) {
+        job.error = `发送状态不确定，继续按 agentId 监控：${e.message}`;
+        if (job.agentId) {
+          job.phase = 'running';
+          this.activeParallel.set(job.id, job);
+          this._monitorParallelAgent(job).catch((monitorError) => this._failParallelJob(job, monitorError));
+        } else {
+          this._orphanParallelJob(job, e);
+        }
+      } else {
+        this._failJob(job, e);
+      }
+    } finally {
+      this.busy = false;
+      this._drain();
+      this._maybeRestoreParallelOrigin();
+    }
   }
 
-  async _run(query) {
+  async _run(prompt, options = {}) {
     const page = await findPage();
     const c = makeClient(page.webSocketDebuggerUrl);
     await c.ready;
     try {
-      // 1) 确保 chat 面板打开（Ctrl+L toggle：不可见才开）
-      let vis = await evalJS(c, EXPR_VISIBLE);
-      if (!vis) { await chord(c, 2, 'L', 'KeyL', 76); await sleep(1300); vis = await evalJS(c, EXPR_VISIBLE); }
-      if (!vis) throw new Error('无法打开 Cursor chat 面板（.aislash-editor-input 不可见）。Cursor 是否登录且窗口正常？');
+      await this._ensureChatPanel(c);
       // 1.5) 开新对话（避免上下文累积 + 回复区干净，extract 不串旧对话）；找不到钮则跳过沿用当前
-      await this._newChat(c);
+      if (options.newChat !== false) await this._newChat(c);
       // 2) 填查询
-      const filled = await evalJS(c, exprFill(SEARCH_PREFIX + query));
+      const filled = await evalJS(c, exprFill(prompt));
       if (filled === 'NO_INPUT' || filled === 'EXEC_FAIL') throw new Error('填入查询失败（输入框状态异常）');
       await sleep(450);
+      let baseline = { messageCount: 0 };
+      try { baseline = JSON.parse(await evalJS(c, EXPR_SNAP)); } catch {}
       // 3) Enter 发送
       await chord(c, 0, 'Enter', 'Enter', 13);
       // 4) 等完成（stop 钮 >0 出现过 → 归 0）
-      return await this._waitComplete(c);
+      return await this._waitComplete(c, options.timeoutMs || QUERY_TIMEOUT, baseline.messageCount || 0);
     } finally { c.close(); }
+  }
+
+  async _ensureChatPanel(c) {
+    let vis = await evalJS(c, EXPR_VISIBLE);
+    if (!vis) {
+      await chord(c, 2, 'L', 'KeyL', 76);
+      await sleep(1300);
+      vis = await evalJS(c, EXPR_VISIBLE);
+    }
+    if (!vis) throw new Error('无法打开 Cursor chat 面板（.aislash-editor-input 不可见）。Cursor 是否登录且窗口正常？');
   }
 
   // 清空对话上下文：定位 "New Agent" 钮后【Alt+click】——Alt 修饰使其执行 Replace Agent（清空旧对话），
   // 而非新建（aria 标注 "New Agent (Ctrl+N) / [Alt] Replace Agent"）。2026-06-08 实测回复区 markdown DOM 清空
   // 2719→17，避免 extract 串旧对话。找不到钮则跳过沿用当前（不阻断查询）。
   async _newChat(c) {
+    return this._clickNewAgent(c, true);
+  }
+
+  async _clickNewAgent(c, replaceCurrent) {
     try {
       const pos = await evalJS(c, EXPR_FIND_NEWAGENT);
       if (!pos) return false;
       const { x, y } = JSON.parse(pos);
-      await c.send('Input.dispatchMouseEvent', { type: 'mousePressed', x, y, button: 'left', clickCount: 1, modifiers: 1 });   // modifiers:1 = Alt → Replace Agent
-      await c.send('Input.dispatchMouseEvent', { type: 'mouseReleased', x, y, button: 'left', clickCount: 1, modifiers: 1 });
+      const modifiers = replaceCurrent ? 1 : 0;
+      await c.send('Input.dispatchMouseEvent', { type: 'mousePressed', x, y, button: 'left', clickCount: 1, modifiers });
+      await c.send('Input.dispatchMouseEvent', { type: 'mouseReleased', x, y, button: 'left', clickCount: 1, modifiers });
       await sleep(1100);   // 等新对话初始化（输入框重建 + 回复区清空）
       return true;
     } catch { return false; }
   }
 
-  async _waitComplete(c) {
+  async _ensureHistoryOpen(c) {
+    if (await evalJS(c, EXPR_HISTORY_OPEN)) return true;
+    const pos = await evalJS(c, EXPR_FIND_HISTORY);
+    if (!pos) return false;
+    const { x, y } = JSON.parse(pos);
+    await c.send('Input.dispatchMouseEvent', { type: 'mousePressed', x, y, button: 'left', clickCount: 1 });
+    await c.send('Input.dispatchMouseEvent', { type: 'mouseReleased', x, y, button: 'left', clickCount: 1 });
+    await sleep(450);
+    return !!(await evalJS(c, EXPR_HISTORY_OPEN));
+  }
+
+  async _closeHistory(c) {
+    try {
+      if (await evalJS(c, EXPR_HISTORY_OPEN)) {
+        await chord(c, 0, 'Escape', 'Escape', 27);
+        await sleep(180);
+      }
+    } catch {}
+  }
+
+  async _readAgentEntries(c, keepOpen = false) {
+    if (!(await this._ensureHistoryOpen(c))) throw new Error('Agent History 菜单不可用');
+    try {
+      const snapshot = JSON.parse(await evalJS(c, EXPR_HISTORY_ENTRIES));
+      if (!snapshot.ok) throw new Error(snapshot.error || 'Agent History React adapter 不可用');
+      return snapshot.entries || [];
+    } finally {
+      if (!keepOpen) await this._closeHistory(c);
+    }
+  }
+
+  async _submitParallelAgent(job) {
+    const page = await findPage();
+    const c = makeClient(page.webSocketDebuggerUrl);
+    await c.ready;
+    let sent = false;
+    try {
+      await this._ensureChatPanel(c);
+      let before;
+      try {
+        before = await this._readAgentEntries(c);
+      } catch (e) {
+        return { fallbackReason: `parallel_agent 前置能力不可用：${e.message}` };
+      }
+      const previousSelectedId = (before.find((e) => e.isSelected) || {}).id || null;
+      if (!(await this._clickNewAgent(c, false))) {
+        return { fallbackReason: '找不到 Cursor New Agent 按钮，已在发送前降级 FIFO' };
+      }
+
+      let agent = null;
+      // 大多数 Cursor 版本在点击 New Agent 后即登记 local:<UUID>；先在发送前绑定身份。
+      for (let i = 0; i < 5 && !agent; i++) {
+        try { agent = selectNewAgentEntry(before, await this._readAgentEntries(c)); } catch {}
+        if (!agent) await sleep(350);
+      }
+      if (agent) {
+        job.agentId = agent.id;
+        job.agentLabel = agent.label || null;
+      }
+
+      await this._closeHistory(c);
+      await this._ensureChatPanel(c);
+      const filled = await evalJS(c, exprFill(job.prompt));
+      if (filled === 'NO_INPUT' || filled === 'EXEC_FAIL') throw new Error('parallel_agent 填入任务失败');
+      await sleep(350);
+      sent = true;
+      await chord(c, 0, 'Enter', 'Enter', 13);
+      job.sentAt = new Date().toISOString();
+
+      // Cursor 3.7 可能只在首次消息发送后才把 composer 登记进 Agent History。
+      // 发送后仍只按 before/after ID 差分绑定；若失败则进入 needs_attention，绝不重发或释放路径。
+      for (let i = 0; i < 12 && !agent; i++) {
+        await sleep(350);
+        try { agent = selectNewAgentEntry(before, await this._readAgentEntries(c)); } catch {}
+      }
+      if (!agent) {
+        const e = new Error('任务可能已发送，但无法从 Agent History 捕获唯一 agentId；已保留占用，禁止自动重发');
+        e.sent = true;
+        throw e;
+      }
+      job.agentId = agent.id;
+      job.agentLabel = agent.label || null;
+      return { agent, previousSelectedId };
+    } catch (e) {
+      if (sent) e.sent = true;
+      throw e;
+    } finally {
+      await this._closeHistory(c);
+      c.close();
+    }
+  }
+
+  async _readParallelEntry(job) {
+    return this._withUiLock(async () => {
+      const page = await findPage();
+      const c = makeClient(page.webSocketDebuggerUrl);
+      await c.ready;
+      try {
+        const entries = await this._readAgentEntries(c);
+        return entries.find((e) => e.id === job.agentId) || null;
+      } finally { c.close(); }
+    });
+  }
+
+  async _monitorParallelAgent(job) {
+    const started = Date.now();
+    let sawGenerating = false;
+    let completedStable = 0;
+    let missingPolls = 0;
+    let transientErrors = 0;
+    let collectionAttempts = 0;
+    let lastCollectionError = '';
+    while (Date.now() - started < job.timeoutMs) {
+      await sleep(1400);
+      let entry;
+      try {
+        entry = await this._readParallelEntry(job);
+        transientErrors = 0;
+      } catch (e) {
+        transientErrors++;
+        // Cursor 切换 Agent、收起侧栏或 History 菜单重渲染时可能短暂不可读。
+        // 保留约一分钟恢复窗口；超出后进入 needs_attention，绝不把已发送任务自动重发。
+        if (transientErrors >= 45) throw new Error(`连续无法读取 Agent History：${e.message}`);
+        continue;
+      }
+      if (!entry) {
+        missingPolls++;
+        if (missingPolls >= 45) throw new Error(`Agent History 中持续丢失 ${job.agentId}`);
+        continue;
+      }
+      missingPolls = 0;
+      if (entry.showSpinner) {
+        sawGenerating = true;
+        completedStable = 0;
+        continue;
+      }
+      if (/error|failed|warning|circle-slash/i.test(entry.icon || '')) {
+        const e = new Error(`Cursor Agent ${job.agentId} 显示失败状态 ${entry.icon}`);
+        e.confirmedTerminal = true;
+        throw e;
+      }
+      const completedIcon = /check-circled|check/i.test(entry.icon || '');
+      if (completedIcon) {
+        completedStable++;
+        // 极短任务可能在首次轮询前已完成；此时以两次稳定完成状态替代 sawGenerating。
+        if (sawGenerating || completedStable >= 2) {
+          job.phase = 'collecting';
+          let result;
+          try {
+            result = await this._withUiLock(() => this._collectParallelAgent(job));
+          } catch (e) {
+            // Agent 已完成但 DOM/React 视图尚未稳定时，不把一次提取失败误判为任务失败。
+            // 继续绑定同一个 agentId 重试；只有 History 明确显示失败图标才是 confirmedTerminal。
+            collectionAttempts++;
+            lastCollectionError = e.message;
+            job.error = `第 ${collectionAttempts} 次回收未完成，继续重试：${e.message}`;
+            job.phase = 'running';
+            completedStable = 0;
+            await sleep(1200);
+            continue;
+          }
+          job.error = null;
+          this.activeParallel.delete(job.id);
+          this._finishJob(job, result);
+          this._drain();
+          this._maybeRestoreParallelOrigin();
+          return;
+        }
+      } else {
+        completedStable = 0;
+      }
+    }
+    const detail = lastCollectionError ? `；最后回收错误：${lastCollectionError}` : '';
+    throw new Error(`Cursor parallel_agent 任务超时 (${job.timeoutMs}ms)${detail}`);
+  }
+
+  async _waitForSelectedAgent(c, agentId, timeoutMs = 15000) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const entries = await this._readAgentEntries(c);
+      const target = entries.find((e) => e.id === agentId);
+      if (target && target.isSelected) return true;
+      await sleep(250);
+    }
+    throw new Error(`打开 ${agentId} 后未确认其成为当前选中 Agent`);
+  }
+
+  async _collectParallelAgent(job) {
+    const page = await findPage();
+    const c = makeClient(page.webSocketDebuggerUrl);
+    await c.ready;
+    let previousSelectedId = null;
+    try {
+      const entries = await this._readAgentEntries(c, true);
+      previousSelectedId = (entries.find((e) => e.isSelected) || {}).id || null;
+      const opened = await evalJS(c, exprOpenAgent(job.agentId));
+      if (opened !== 'OPENED') throw new Error(`无法打开 ${job.agentId}: ${opened}`);
+      await this._closeHistory(c);
+      await this._waitForSelectedAgent(c, job.agentId);
+
+      let answer = '';
+      let lastKey = '';
+      let stable = 0;
+      // Agent History 已给出完成图标，但打开会话后的 Markdown/虚拟列表仍可能延迟挂载。
+      // 给视图约 24 秒稳定时间，并允许只有一个可见 Markdown（常见于用户 prompt 不是 markdown 的情况）。
+      for (let i = 0; i < 80; i++) {
+        let snap = { messageCount: 0, replyLength: 0, replyHash: 0 };
+        try { snap = JSON.parse(await evalJS(c, EXPR_SNAP)); } catch {}
+        const candidate = String(await evalJS(c, EXPR_EXTRACT) || '').trim();
+        if (candidate && Number(snap.stop || 0) === 0) {
+          const key = `${snap.replyLength}:${snap.replyHash}`;
+          if (key === lastKey) stable++; else { lastKey = key; stable = 0; }
+          if (stable >= 1) { answer = candidate; break; }
+        }
+        await sleep(300);
+      }
+      if (!answer) throw new Error(`已打开 ${job.agentId}，但未找到助手最终回复`);
+
+      if (previousSelectedId && previousSelectedId !== job.agentId) {
+        if (await this._ensureHistoryOpen(c)) {
+          await evalJS(c, exprOpenAgent(previousSelectedId));
+          await this._closeHistory(c);
+          await this._waitForSelectedAgent(c, previousSelectedId);
+        }
+      }
+      return answer;
+    } finally {
+      await this._closeHistory(c);
+      c.close();
+    }
+  }
+
+  _failParallelJob(job, error) {
+    if (error && error.confirmedTerminal) {
+      this.activeParallel.delete(job.id);
+      this._failJob(job, error);
+      this._drain();
+      this._maybeRestoreParallelOrigin();
+      return;
+    }
+    this._orphanParallelJob(job, error);
+  }
+
+  _maybeRestoreParallelOrigin() {
+    if (!this.parallelRestoreAgentId || this.busy || this.activeParallel.size > 0 ||
+        this.queue.some((job) => job.execution === 'parallel_agent')) return;
+    const agentId = this.parallelRestoreAgentId;
+    this.parallelRestoreAgentId = null;
+    this._withUiLock(async () => {
+      const page = await findPage();
+      const c = makeClient(page.webSocketDebuggerUrl);
+      await c.ready;
+      try {
+        if (await this._ensureHistoryOpen(c)) {
+          await evalJS(c, exprOpenAgent(agentId));
+          await sleep(450);
+        }
+      } finally {
+        await this._closeHistory(c);
+        c.close();
+      }
+    }).catch((e) => console.error('⚠️ 恢复原 Cursor Agent 失败：' + e.message));
+  }
+
+  async _waitComplete(c, timeoutMs = QUERY_TIMEOUT, baselineCount = 0) {
     const start = Date.now();
     const INTERVAL = 1000;
     let sawStop = false;        // 观察到生成中（stop 钮出现过）
-    let lastMd = 0, stableMd = 0;
+    let lastReplyKey = '', stableReply = 0;
     await sleep(1200);          // 给发送后 stop 钮起来留时间
-    while (Date.now() - start < QUERY_TIMEOUT) {
-      let s; try { s = JSON.parse(await evalJS(c, EXPR_SNAP)); } catch { s = { stop: 0, mdMax: 0 }; }
+    while (Date.now() - start < timeoutMs) {
+      let s;
+      try { s = JSON.parse(await evalJS(c, EXPR_SNAP)); }
+      catch { s = { stop: 0, messageCount: 0, replyLength: 0, replyHash: 0 }; }
       if (s.stop > 0) sawStop = true;
 
-      // 主路径：生成过且停止钮归 0 + 有实质回复 → 完成
-      if (sawStop && s.stop === 0 && s.mdMax > 40) {
+      // 主路径：确认生成过、停止钮归零且存在非空回复；不再硬编码回复长度。
+      if (sawStop && s.stop === 0 && s.replyLength > 0) {
         await sleep(800);      // 宽限：最后一次 DOM 追加
         const ans = await evalJS(c, EXPR_EXTRACT);
-        if (ans && ans.length > 0) return ans;
+        if (ans) return ans;
       }
-      // 兜底：始终没采到 stop 钮（信号失效）但文本稳定 → 完成
-      if (!sawStop && s.mdMax > 80) {
-        if (s.mdMax === lastMd) { stableMd++; if (stableMd >= 6) { const ans = await evalJS(c, EXPR_EXTRACT); if (ans) return ans; } }
-        else { stableMd = 0; lastMd = s.mdMax; }
+      // 兜底：没采到 stop 时，必须比发送前多出用户+助手两条消息，并且最后回复稳定。
+      if (!sawStop && s.messageCount >= baselineCount + 2 && s.replyLength > 0) {
+        const key = `${s.replyLength}:${s.replyHash}`;
+        if (key === lastReplyKey) {
+          stableReply++;
+          if (stableReply >= 4) {
+            const ans = await evalJS(c, EXPR_EXTRACT);
+            if (ans) return ans;
+          }
+        } else {
+          stableReply = 0;
+          lastReplyKey = key;
+        }
       }
       await sleep(INTERVAL);
     }
-    // 超时：有内容则返回当前，否则报错（绝不返回空）
+    // 超时只接受已观察到生成，或消息数明确增加到助手回复；避免把用户 prompt 当结果。
+    let finalSnap = { messageCount: 0 };
+    try { finalSnap = JSON.parse(await evalJS(c, EXPR_SNAP)); } catch {}
     const ans = await evalJS(c, EXPR_EXTRACT);
-    if (ans && ans.length > 40) return ans;
-    throw new Error(`Cursor 查询超时 (${QUERY_TIMEOUT}ms) 未产生实质回复`);
+    if (ans && (sawStop || finalSnap.messageCount >= baselineCount + 2)) return ans;
+    throw new Error(`Cursor 任务超时 (${timeoutMs}ms) 未产生可确认的助手回复`);
   }
 
-  async status() {
+  _taskView(job, includeResult = false) {
+    const view = {
+      taskId: job.id,
+      kind: job.kind,
+      status: job.status,
+      phase: job.phase,
+      execution: job.execution,
+      effectiveExecution: job.effectiveExecution,
+      readOnly: job.readOnly,
+      allowedPaths: job.allowedPaths,
+      agentId: job.agentId,
+      agentLabel: job.agentLabel,
+      fallbackReason: job.fallbackReason,
+      createdAt: job.createdAt,
+      startedAt: job.startedAt,
+      sentAt: job.sentAt,
+      finishedAt: job.finishedAt,
+      error: job.error,
+    };
+    if (includeResult || job.status === 'completed' || job.status === 'failed') view.result = job.result;
+    return view;
+  }
+
+  _trimTasks() {
+    if (this.tasks.size <= 50) return;
+    for (const [id, job] of this.tasks) {
+      if (job.status === 'completed' || job.status === 'failed') this.tasks.delete(id);
+      if (this.tasks.size <= 50) break;
+    }
+  }
+
+  async status(taskId = '') {
+    if (taskId) {
+      const job = this.tasks.get(String(taskId));
+      if (!job) return { found: false, taskId: String(taskId) };
+      return { found: true, ...this._taskView(job, true) };
+    }
+    const parallelRunning = this.activeParallel.size;
+    const uiBusy = this.busy;
+    const common = {
+      busy: uiBusy || parallelRunning > 0 || this.queue.length > 0,
+      uiBusy,
+      parallelRunning,
+      idle: !uiBusy && parallelRunning === 0 && this.queue.length === 0,
+      queued: this.queue.length,
+      activeParallel: [...this.activeParallel.values()].map((job) => this._taskView(job)),
+      recentTasks: [...this.tasks.values()].slice(-10).map((job) => this._taskView(job)),
+      cdpPort: CDP_PORT,
+    };
     try {
       const ver = await httpJson('/json/version');
       const page = await findPage();
-      return { connected: true, busy: this.busy, queued: this.queue.length, cdpPort: CDP_PORT, browser: ver.Browser, page: (page.url || '').slice(0, 60) };
+      return { connected: true, ...common, browser: ver.Browser, page: (page.url || '').slice(0, 60) };
     } catch (e) {
-      return { connected: false, busy: this.busy, queued: this.queue.length, cdpPort: CDP_PORT, error: e.message };
+      return { connected: false, ...common, error: e.message };
     }
   }
 }
 
 const bridge = new CursorBridge();
-const server = new Server({ name: 'cursor-bridge', version: '1.0.0' }, { capabilities: { tools: {} } });
+const server = new Server({ name: 'cursor-bridge', version: '2.0.7' }, { capabilities: { tools: {} } });
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [
@@ -247,9 +910,31 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       },
     },
     {
+      name: 'cursor_do',
+      description:
+        '把边界明确的任务交给 Cursor agent 执行。默认 execution=fifo 后台排队；' +
+        'execution=parallel_agent 会串行操控 UI 提交到独立顶层 Agent，再按稳定 agentId 并行跟踪和逐项收回。' +
+        '并行写任务必须提供不重叠的 allowed_paths；只读任务应设置 read_only=true。' +
+        '用 cursor_status(task_id) 查询状态和原始回复。Cursor 结果不是正式验证，主 Agent 仍需检查真实改动。',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          prompt: { type: 'string', description: '原样交给 Cursor 的任务内容，必须包含明确目标、边界和完成合同' },
+          background: { type: 'boolean', default: true, description: '默认 true：立即返回 taskId；false：等待该任务进入终态' },
+          execution: { type: 'string', enum: ['fifo', 'parallel_agent'], default: 'fifo', description: 'fifo 保持单对话串行；parallel_agent 使用独立顶层 Agent 并行运行' },
+          read_only: { type: 'boolean', default: false, description: '显式声明任务不得修改工作区；parallel_agent 只读任务应设 true' },
+          new_chat: { type: 'boolean', default: true, description: 'fifo 是否使用干净对话；parallel_agent 始终强制独立 New Agent' },
+          timeout_ms: { type: 'integer', minimum: 30000, maximum: 900000, default: 600000, description: '单任务超时，默认 10 分钟' },
+          allowed_paths: { type: 'array', items: { type: 'string' }, description: '工作区相对路径的写入范围声明；并行写任务必填、不得含 glob/越界，且不得与活动并行任务重叠。它不是文件系统沙箱' },
+          completion_contract: { type: 'string', description: '可选：自定义验收和最终回报格式' },
+        },
+        required: ['prompt'],
+      },
+    },
+    {
       name: 'cursor_status',
-      description: '检查 cursor-bridge 与 Cursor CDP（9223）的连接/队列状态。',
-      inputSchema: { type: 'object', properties: {} },
+      description: '检查 Cursor CDP、FIFO 队列和活动并行 Agent；传 task_id 可精确查询 cursor_do 的 agentId、阶段与结果。',
+      inputSchema: { type: 'object', properties: { task_id: { type: 'string', description: '可选：cursor_do 返回的 taskId' } } },
     },
     {
       name: 'cursor_launch',
@@ -268,8 +953,20 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const result = await bridge.search(String((args && args.query) || ''));
       return { content: [{ type: 'text', text: String(result) }] };
     }
+    if (name === 'cursor_do') {
+      const result = await bridge.doTask(String((args && args.prompt) || ''), {
+        background: !args || args.background !== false,
+        execution: args && args.execution,
+        readOnly: !!(args && args.read_only),
+        newChat: !args || args.new_chat !== false,
+        timeoutMs: args && args.timeout_ms,
+        allowedPaths: args && args.allowed_paths,
+        completionContract: args && args.completion_contract,
+      });
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    }
     if (name === 'cursor_status') {
-      return { content: [{ type: 'text', text: JSON.stringify(await bridge.status(), null, 2) }] };
+      return { content: [{ type: 'text', text: JSON.stringify(await bridge.status(args && args.task_id), null, 2) }] };
     }
     if (name === 'cursor_launch') {
       const { ensureCursorRunning } = await import('./launch-cursor.mjs');
@@ -306,4 +1003,4 @@ if (isMain) {
   process.on('SIGINT', () => process.exit(0));
   main().catch((e) => { console.error('❌ 致命错误:', e); process.exit(1); });
 }
-export { CursorBridge, bridge };
+export { CursorBridge, bridge, normalizeAllowedPath, pathsOverlap, selectNewAgentEntry };

--- a/skills/cursor-delegate/SKILL.md
+++ b/skills/cursor-delegate/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: cursor-delegate
+description: "将主 Agent 已规划、边界明确且可独立验收的中轻型实现、文档、配置或工具任务委托给 Cursor Bridge；支持 execution=fifo 串行执行，以及仅在任务互不依赖、写入路径不重叠时使用 execution=parallel_agent 派发多个顶层 Cursor Agent，再按 task_id/agent_id 收回并由主 Agent 复核。Use when planned execution work is ready to hand off, the user asks Cursor to execute bounded work, or several independent tasks can run concurrently. Do not use to delegate product direction, scope or architecture decisions, Unity Scene/Prefab or PlayMode operations, formal verification verdicts, Tower state decisions, or unbounded investigation."
+---
+
+# Cursor Delegate
+
+把 Cursor 当作执行副手。主 Agent 始终保留方向判断、范围裁决、结果审查和正式验证。
+
+## 日常默认工作流
+
+按以下职责链使用：
+
+`主 Agent 调查与裁定范围 → 形成独立任务信封 → Cursor 执行 → cursor_status 按 task_id 收回 → 主 Agent 检查真实改动并验证`
+
+- 主 Agent 决定做什么、为什么做、允许改哪里、如何验收；不要把这些判断转交 Cursor。
+- Cursor 负责已决定方案内的检索、窄实现、文档、配置、脚本和工具修改。
+- 默认一项任务调用一次 `cursor_do`，使用 `background=true`、`new_chat=true`；主 Agent 可在后台继续不冲突的工作。
+- 默认选择 `execution=fifo`。只有确实需要同时推进且满足并行合同的任务才使用 `parallel_agent`。
+- 不注入唯一终止标记，不设置最小回复长度。完成判断只依赖任务状态、稳定 `task_id/agent_id` 和实际结果。
+
+## 检查委托门禁
+
+仅在以下条件全部成立时委托：
+
+- 目标、范围和预期结果已经决定。
+- 每项任务都有明确的完成合同，并可被独立检查。
+- 任务不要求 Cursor 自行决定产品、架构、世界观或 Tower 状态。
+- 不涉及 Unity Scene/Prefab、PlayMode 状态或其他独占 GUI 操作。
+- 能识别并保留工作区已有的用户改动。
+
+若派发、等待和复核成本高于直接完成，主 Agent 直接执行。
+
+## 选择执行方式
+
+- 使用 `execution=fifo`：单个日常中轻型任务，或任务存在前后依赖、写入范围相交、共享可变状态、无法证明相互独立。依赖任务必须在上一项验收后再提交下一项。
+- 使用 `execution=parallel_agent`：至少两个任务互不依赖、可分别验收，且所有写入路径互不重叠。
+- 设置 `read_only=true`：任务只允许查询、分析或返回文本，不得修改文件。只读任务仍不得并行操作同一个外部可变状态。
+- 设置 `read_only=false`：必须提供非空、无 glob、不会越出工作区的相对 `allowed_paths`。把范围缩到完成任务所需的最小路径集合；它是调度冲突声明和 prompt 约束，不是文件系统沙箱。
+
+不得仅因任务数量多就选择并行。无法确认依赖或路径关系时，默认使用 `fifo`。
+
+## 派发任务
+
+1. 记录相关工作区的派发前状态，用于区分用户已有改动。
+2. 按 [delegation-contract.md](references/delegation-contract.md) 为每项任务形成独立任务信封。
+3. 默认使用 `background=true` 和 `new_chat=true` 调用 `cursor_do`。
+4. 为每项任务保存返回的 `task_id`；`parallel_agent` 还必须保存 `agent_id`。
+5. 若并行任务未返回可用的 `agent_id`，不要继续扩大并行批次；转为 `fifo` 或报告歧义状态。
+
+## 收回结果
+
+1. 始终用 `cursor_status(task_id)` 查询对应任务，不把当前可见的 Cursor 对话当作任务身份。
+2. `submitting/running/collecting` 都是正常进行态；耗时超过两分钟本身不是失败。等待明确终态后再读取结果。
+3. 将 Cursor 声明的改动与真实 diff、`allowed_paths` 和完成合同逐项对照。
+4. 由主 Agent 运行风险匹配的验证。Cursor 回复不能单独支持“通过”、`Verified` 或 Tower 状态推进。
+5. 分别记录每项任务为完成、部分完成、失败、超时或歧义，再汇总整个批次。
+
+状态解释与恢复细节见 [delegation-contract.md](references/delegation-contract.md)。
+
+## 处理异常
+
+- 任务状态为 `needs_attention/orphaned`、歧义或会话无法绑定：视为真实 Cursor Agent 可能仍在运行，保留路径占用，先按 `task_id/agent_id` 检查历史，不要盲目重复提交。
+- Cursor UI 已有最终回复但 Bridge 尚未收回：继续查询原 `task_id`，不得添加终止标记、扩大回复长度或重新派发同一任务。新版 Bridge 会在同一 `agent_id` 上重试；持续失败才进入 `needs_attention`。
+- 任务超时但已产生修改：先审查修改，再决定续做、重试或回退。
+- 修改越过 `allowed_paths`：停止接收该结果并报告越界。
+- 并行任务出现文件冲突：停止后续合并，交由主 Agent 审查并改为串行处理。

--- a/skills/cursor-delegate/agents/openai.yaml
+++ b/skills/cursor-delegate/agents/openai.yaml
@@ -1,0 +1,13 @@
+interface:
+  display_name: "Cursor 委托执行"
+  short_description: "将已规划的中轻型任务委托给 Cursor，支持安全并行、收回与复核"
+  default_prompt: "使用 $cursor-delegate 将这组已规划、边界明确的中轻型任务安全委托给 Cursor，并逐项收回和复核结果。"
+
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "cursor-bridge"
+      description: "通过 CDP 派发、跟踪并收回 Cursor 顶层 Agent 任务"
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/cursor-delegate/references/delegation-contract.md
+++ b/skills/cursor-delegate/references/delegation-contract.md
@@ -1,0 +1,96 @@
+# Cursor 委托合同
+
+只在构造任务信封、选择 `execution` 或处理异常状态时读取本文件。
+
+## 任务信封
+
+每项任务必须独立提供：
+
+| 字段 | 要求 |
+|---|---|
+| `prompt` | 写明单一目标、必要上下文、禁止动作和预期回报；不得让 Cursor 重做主 Agent 的范围裁决。 |
+| `execution` | 只能使用 `fifo` 或 `parallel_agent`。无法证明安全并行时使用 `fifo`。 |
+| `read_only` | 查询与分析使用 `true`；任何文件修改使用 `false`。 |
+| `allowed_paths` | `read_only=false` 时必填，使用最小工作区相对路径集合；不得含 glob、绝对路径或越出工作区的 `..`。`read_only=true` 时不得同时传此字段。它不是文件系统沙箱。 |
+| `completion_contract` | 写明交付物、验证命令、允许的未完成项和最终回报格式。 |
+| `background` | 默认 `true`，让主 Agent 可继续处理独立工作。 |
+| `new_chat` | 默认 `true`，为任务建立干净的顶层 Cursor Agent。 |
+
+## 路由合同
+
+选择 `parallel_agent` 前必须同时满足：
+
+1. 各任务没有数据、顺序或决策依赖。
+2. 写任务的规范化 `allowed_paths` 两两不重叠。
+3. 任务不共享 Unity、浏览器、数据库或其他可变运行时状态。
+4. 每项结果可以单独验收；一项失败不会使其他结果失去意义。
+
+任一条件不成立就使用 `fifo`。存在顺序依赖时，不要预先提交整个队列；先收回并验收前序任务，再决定是否提交后序任务。
+
+## 调用样例
+
+只读并行任务：
+
+```json
+{
+  "prompt": "读取指定文件并返回结论，不修改任何文件。",
+  "execution": "parallel_agent",
+  "read_only": true,
+  "background": true,
+  "new_chat": true,
+  "completion_contract": "返回结论、依据文件与未确认项。"
+}
+```
+
+受限写任务：
+
+```json
+{
+  "prompt": "按既定方案完成指定工具脚本，不扩大范围。",
+  "execution": "parallel_agent",
+  "read_only": false,
+  "background": true,
+  "new_chat": true,
+  "allowed_paths": ["Tools/Example/"],
+  "completion_contract": "列出改动文件并运行指定静态验证；失败时保留原始错误。"
+}
+```
+
+有依赖或路径相交的任务把 `execution` 改为 `fifo`，并在前序任务验收后再派发下一项。
+
+## 身份与收回合同
+
+- `task_id` 是主 Agent 查询和汇总任务的稳定身份；每次派发后立即保存。
+- `agent_id` 把 `parallel_agent` 任务绑定到 Agents Window 中的独立顶层会话；并行任务缺少该字段时不得假定身份安全。
+- 只通过 `cursor_status(task_id)` 判断对应任务状态，不依赖当前选中的对话或最新一条回复。
+- 结果至少应包含：任务状态、摘要、改动文件、执行的验证、失败或阻塞，以及原始 Cursor 回复。
+- 不要求 Cursor 输出唯一终止标记或满足最小回复长度；Bridge 以 Agent 状态、停止生成和回答内容稳定性判断完成。
+
+### 状态表
+
+| 状态 / phase | 主 Agent 行为 |
+|---|---|
+| `queued/submitting/running/collecting` | 保持原任务，继续按 `task_id` 轮询；超过两分钟不构成失败。 |
+| `completed` | 读取原始回复，再检查真实 diff、允许路径和完成合同。 |
+| `failed` | 读取明确错误；先判断 Cursor Agent 是否真的显示失败，再决定是否返工。 |
+| `needs_attention/orphaned` | 任务可能仍在运行或结果未成功回收；保留路径占用，按 `agent_id` 检查 Agent History，不自动重发。 |
+
+R6 型假阴性处理：若 Agent History 中已存在完整最终回复而自动回收暂未完成，继续查询原 `task_id`。Bridge 应绑定原 `agent_id` 重试提取；禁止通过增加回复长度、注入终止标记或再次提交相同任务规避回收问题。
+
+## 主 Agent 验收合同
+
+Cursor 的完成声明只表示委托执行结束，不是项目验证结论。主 Agent 必须：
+
+1. 检查实际 diff 与 `allowed_paths`。
+2. 区分委托改动和派发前已有改动。
+3. 独立运行适当的编译、静态检查、测试或旅程验证。
+4. 自行决定接受、返工、串行续做或登记阻塞。
+5. 保留正式验证、Tower 状态和产品裁决权。
+
+## 失败与降级
+
+- `agent_id` 缺失且任务尚未发送：停止扩大并行批次，可安全降级 `fifo`。任务可能已发送或状态为 `needs_attention/orphaned` 时，继续视为占用路径并检查 Agents Window，不得自动重发。
+- 超时但工作区已有修改：先审查修改，不直接重复派发同一任务。
+- 越过 `allowed_paths`：拒绝接收并报告越界文件。
+- 并行任务产生冲突：停止自动汇总，转由主 Agent 审查。
+- Agent History 或回答 DOM 短暂不可读：允许 Bridge 在同一 `agent_id` 上等待并重试；持续不可读时进入 `needs_attention`，不得误判为已完成或另起相同 Agent。

--- a/test/bridge.test.mjs
+++ b/test/bridge.test.mjs
@@ -1,0 +1,128 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  CursorBridge,
+  normalizeAllowedPath,
+  pathsOverlap,
+  selectNewAgentEntry,
+} from '../server.mjs';
+
+class OfflineBridge extends CursorBridge {
+  async _ensureCursor() {}
+  _drain() {}
+}
+
+test('allowed path normalization and prefix overlap are deterministic', () => {
+  assert.equal(normalizeAllowedPath('Assets\\Scripts\\'), 'assets/scripts');
+  assert.equal(normalizeAllowedPath('./Assets//Scripts/../Scripts/Battle'), 'assets/scripts/battle');
+  assert.equal(pathsOverlap('Assets/Scripts', 'assets/scripts/Battle'), true);
+  assert.equal(pathsOverlap('Assets/Foo', './Assets/Bar/../Foo'), true);
+  assert.equal(pathsOverlap('Assets/Scripts/A', 'Assets/Scripts/B'), false);
+  assert.equal(pathsOverlap('.', 'Assets/Scripts'), true);
+});
+
+test('new agent selection uses ID diff, selected entry, then newest timestamp', () => {
+  const before = [{ id: 'local:old' }];
+  assert.equal(selectNewAgentEntry(before, before), null);
+  assert.equal(selectNewAgentEntry(before, [
+    ...before,
+    { id: 'local:a', timestamp: 20, isSelected: false },
+    { id: 'local:b', timestamp: 10, isSelected: true },
+  ]).id, 'local:b');
+  assert.equal(selectNewAgentEntry(before, [
+    ...before,
+    { id: 'local:a', timestamp: 20, isSelected: false },
+    { id: 'local:b', timestamp: 10, isSelected: false },
+  ]).id, 'local:a');
+});
+
+test('cursor_do defaults to FIFO and keeps background task identity', async () => {
+  const bridge = new OfflineBridge();
+  const view = await bridge.doTask('检查一个明确任务');
+  assert.equal(view.status, 'queued');
+  assert.equal(view.execution, 'fifo');
+  assert.equal(view.effectiveExecution, 'fifo');
+  assert.match(view.taskId, /^cursor-/);
+});
+
+test('parallel agent requires read_only or a writable path boundary', async () => {
+  const bridge = new OfflineBridge();
+  await assert.rejects(
+    bridge.doTask('无边界写任务', { execution: 'parallel_agent' }),
+    /必须提供 allowed_paths/,
+  );
+  const view = await bridge.doTask('只读任务', { execution: 'parallel_agent', readOnly: true });
+  assert.equal(view.execution, 'parallel_agent');
+  assert.equal(view.readOnly, true);
+  await assert.rejects(
+    bridge.doTask('矛盾边界', { execution: 'parallel_agent', readOnly: true, allowedPaths: ['Assets'] }),
+    /不能同时使用/,
+  );
+  await assert.rejects(
+    bridge.doTask('绝对路径', { execution: 'parallel_agent', allowedPaths: ['G:/repo/file.txt'] }),
+    /必须使用工作区相对路径/,
+  );
+  await assert.rejects(
+    bridge.doTask('glob 路径', { execution: 'parallel_agent', allowedPaths: ['Assets/**/*.cs'] }),
+    /不接受 glob/,
+  );
+});
+
+test('overlapping writable parallel tasks are rejected before submission', async () => {
+  const bridge = new OfflineBridge();
+  await bridge.doTask('任务 A', {
+    execution: 'parallel_agent',
+    allowedPaths: ['Assets/Scripts/Battle'],
+  });
+  await assert.rejects(
+    bridge.doTask('任务 B', {
+      execution: 'parallel_agent',
+      allowedPaths: ['Assets/Scripts/Battle/Effects'],
+    }),
+    /allowed_paths 与任务 .* 重叠/,
+  );
+});
+
+test('unsupported execution mode is rejected explicitly', async () => {
+  const bridge = new OfflineBridge();
+  await assert.rejects(bridge.doTask('任务', { execution: 'multitask' }), /只能是 fifo 或 parallel_agent/);
+});
+
+test('uncertain parallel terminal state remains reserved as needs_attention', async () => {
+  const bridge = new OfflineBridge();
+  const view = await bridge.doTask('可能仍在运行的写任务', {
+    execution: 'parallel_agent',
+    allowedPaths: ['Tools/Reserved'],
+  });
+  const job = bridge.tasks.get(view.taskId);
+  bridge._orphanParallelJob(job, new Error('history unavailable'));
+  assert.equal(job.status, 'needs_attention');
+  assert.equal(job.phase, 'orphaned');
+  assert.equal(bridge.activeParallel.has(job.id), true);
+  await assert.rejects(
+    bridge.doTask('重叠写任务', {
+      execution: 'parallel_agent',
+      allowedPaths: ['Tools/Reserved/Sub'],
+    }),
+    /重叠/,
+  );
+});
+
+test('UI lock serializes operations without poisoning later work after rejection', async () => {
+  const bridge = new CursorBridge();
+  const order = [];
+  const first = bridge._withUiLock(async () => {
+    order.push('a:start');
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    order.push('a:end');
+    throw new Error('expected');
+  });
+  const second = bridge._withUiLock(async () => {
+    order.push('b');
+    return 42;
+  });
+  await assert.rejects(first, /expected/);
+  assert.equal(await second, 42);
+  assert.deepEqual(order, ['a:start', 'a:end', 'b']);
+});

--- a/test/live-parallel-agent.mjs
+++ b/test/live-parallel-agent.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+import { CursorBridge } from '../server.mjs';
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const stamp = Date.now().toString(36).toUpperCase();
+const markerA = `CURSOR_BRIDGE_PARALLEL_A_${stamp}`;
+const markerB = `CURSOR_BRIDGE_PARALLEL_B_${stamp}`;
+const bridge = new CursorBridge();
+
+const common = {
+  execution: 'parallel_agent',
+  readOnly: true,
+  background: true,
+  timeoutMs: 120000,
+  completionContract: '不得读写文件。完成后最终回复只包含指定标记，不添加解释。',
+};
+
+const a = await bridge.doTask(
+  `这是只读并行桥接测试 A。不要读取或修改文件。在终端执行 PowerShell Start-Sleep -Seconds 8，随后最终只回复 ${markerA}`,
+  common,
+);
+const b = await bridge.doTask(
+  `这是只读并行桥接测试 B。不要读取或修改文件。在终端执行 PowerShell Start-Sleep -Seconds 10，随后最终只回复 ${markerB}`,
+  common,
+);
+
+console.log(JSON.stringify({ event: 'submitted', a: a.taskId, b: b.taskId }));
+let sawTwoAgents = false;
+let finalA;
+let finalB;
+const deadline = Date.now() + 150000;
+while (Date.now() < deadline) {
+  const [sa, sb, all] = await Promise.all([
+    bridge.status(a.taskId),
+    bridge.status(b.taskId),
+    bridge.status(),
+  ]);
+  const ids = [sa.agentId, sb.agentId].filter(Boolean);
+  if (new Set(ids).size === 2 && all.activeParallel.length >= 2) sawTwoAgents = true;
+  console.log(JSON.stringify({
+    event: 'poll',
+    a: { status: sa.status, phase: sa.phase, agentId: sa.agentId },
+    b: { status: sb.status, phase: sb.phase, agentId: sb.agentId },
+    activeParallel: all.activeParallel.length,
+  }));
+  if (sa.status === 'failed' || sb.status === 'failed') {
+    throw new Error(`parallel task failed: A=${sa.error || '-'} B=${sb.error || '-'}`);
+  }
+  if (sa.status === 'completed' && sb.status === 'completed') {
+    finalA = sa;
+    finalB = sb;
+    break;
+  }
+  await sleep(1200);
+}
+
+if (!finalA || !finalB) throw new Error('parallel tasks did not both reach completed');
+if (!sawTwoAgents) throw new Error('did not observe two distinct active top-level agents');
+if (!String(finalA.result || '').includes(markerA)) throw new Error(`A result mismatch: ${finalA.result}`);
+if (!String(finalB.result || '').includes(markerB)) throw new Error(`B result mismatch: ${finalB.result}`);
+if (finalA.agentId === finalB.agentId) throw new Error('parallel tasks share the same agentId');
+
+await sleep(1200);
+console.log(JSON.stringify({
+  event: 'passed',
+  sawTwoAgents,
+  a: { taskId: finalA.taskId, agentId: finalA.agentId, result: finalA.result },
+  b: { taskId: finalB.taskId, agentId: finalB.agentId, result: finalB.result },
+}));


### PR DESCRIPTION
## What changed

- add `cursor_do` for bounded delegated execution with FIFO and safe top-level Cursor Agent parallel modes
- track delegated work by stable `task_id` and `agent_id`, with writable path overlap protection
- harden Agent History result collection and retry the same agent instead of using reply-length or terminator-marker heuristics
- add the shared `cursor-delegate` skill and delegation contract
- keep Claude Code and Codex manifests, marketplace metadata, documentation, and version `2.1.0` aligned
- rebuild the zero-dependency `dist/cursor-bridge.mjs` bundle

## Why

This promotes the locally proven `cursor_do` workflow into the upstream dual-runtime plugin while preserving the main agent's responsibility for planning, review, and verification.

## Validation

- `npm run build`
- `npm test` - 8/8 passed
- `node --check server.mjs`
- `node --check dist/cursor-bridge.mjs`
- `skill-creator/scripts/quick_validate.py skills/cursor-delegate`
- `plugin-creator/scripts/validate_plugin.py .`
- `claude plugin validate .`
- four-way version consistency check for package, Claude plugin, Claude marketplace, and Codex plugin