### PR TITLE
feat: add cursor delegation switch

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "cursor-bridge",
       "source": ".",
       "description": "从 Claude Code 直驱 Cursor IDE agent 做语义检索与委托执行，支持 FIFO 和安全的顶层 Agent 并行模式。需 Cursor 带 --remote-debugging-port=9223 在跑。",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "author": {
         "name": "Vanyangyang"
       }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cursor-bridge",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "从 Claude Code 直驱 Cursor IDE agent 做语义检索与边界明确的委托执行，支持 FIFO 和安全的顶层 Agent 并行模式。",
   "author": {
     "name": "Vanyangyang"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cursor-bridge",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Drive Cursor IDE agents over CDP for semantic search and bounded delegated execution, including safe top-level Agent parallelism.",
   "author": {
     "name": "Vanyangyang"
@@ -20,7 +20,7 @@
   "interface": {
     "displayName": "Cursor Bridge",
     "shortDescription": "Delegate bounded work to Cursor with safe Agent parallelism.",
-    "longDescription": "Expose cursor_search, cursor_do, cursor_status, and cursor_launch. Cursor Bridge can retain FIFO compatibility or submit independent bounded tasks to separate top-level Cursor Agents, track them by stable agent ID, and collect each result without using Cursor /multitask.",
+    "longDescription": "Expose cursor_search, cursor_status, cursor_launch, and—unless CURSOR_BRIDGE_DELEGATION=off—cursor_do. Cursor Bridge can retain FIFO compatibility or submit independent bounded tasks to separate top-level Cursor Agents, track them by stable agent ID, and collect each result without using Cursor /multitask.",
     "developerName": "Vanyangyang",
     "category": "Developer Tools",
     "capabilities": [
@@ -28,8 +28,8 @@
     ],
     "defaultPrompt": [
       "Use Cursor Bridge to search this project with Cursor's semantic agent.",
-      "Use cursor_do to delegate this planned bounded task, then query cursor_status and verify the real result.",
-      "Submit these independent non-overlapping tasks as separate top-level Cursor Agents and collect them by task ID."
+      "When cursor_do is available, delegate this planned bounded task, then query cursor_status and verify the real result; otherwise complete it directly.",
+      "When cursor_do is available, submit independent non-overlapping tasks as separate top-level Cursor Agents and collect them by task ID; otherwise keep execution in the main agent."
     ],
     "websiteURL": "https://github.com/Vanyangyang/cursor-bridge"
   }

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ server 启动时会**自动确保 Cursor 带 CDP 在跑**（fire-and-forget）�
 | 工具 | 作用 |
 |------|------|
 | `cursor_search` | 用 Cursor agent 检索定位代码，入参 `query`（自然语言意图）。返回 `path:行号` 清单。单次约 ~90s（实测 66~175s 波动）、串行。 |
-| `cursor_do` | 委托边界明确的任务。`execution=fifo` 保持兼容；`execution=parallel_agent` 提交独立顶层 Agent。并行只读任务设 `read_only=true`；并行写任务必须给出两两不重叠的 `allowed_paths`。 |
+| `cursor_do` | 委托边界明确的任务。`execution=fifo` 保持兼容；`execution=parallel_agent` 提交独立顶层 Agent。并行只读任务设 `read_only=true`；并行写任务必须给出两两不重叠的 `allowed_paths`。设置 `CURSOR_BRIDGE_DELEGATION=off` 后不再暴露。 |
 | `cursor_status` | 检查 CDP、队列、活动并行 Agent；传 `task_id` 精确取回对应状态与原始回复。 |
 | `cursor_launch` | 确保 Cursor 带 CDP 调试口在运行；未运行则自动拉起（带 `--remote-debugging-port` + `--remote-allow-origins` + 打开项目建索引）。返回 `already`/`launched`/`running-no-debug`/`port-not-cursor`/`no-exe`/`timeout`。 |
 
@@ -92,8 +92,18 @@ server 启动时会**自动确保 Cursor 带 CDP 在跑**（fire-and-forget）�
 | `CURSOR_BRIDGE_CDP_PORT` | `9223` | Cursor 远程调试端口 |
 | `CURSOR_BRIDGE_TIMEOUT` | `180000` | 单次查询超时（ms） |
 | `CURSOR_BRIDGE_NO_AUTOLAUNCH` | — | 设 `1` 关闭启动即自动拉起 Cursor |
+| `CURSOR_BRIDGE_DELEGATION` | `on` | 设 `off` 禁用并隐藏 `cursor_do`；`cursor_search`、`cursor_status`、`cursor_launch` 保持可用。修改后需重启 MCP server / Codex / Claude Code。 |
 | `CURSOR_PROJECT_PATH` | 自动判断 | 让 Cursor 打开/建索引的项目根；未设置且运行目录是插件缓存时，不传路径并让 Cursor 恢复上次工作区 |
 | `CURSOR_EXE` | 自动探测 | `Cursor.exe` 路径（自动探测失败时显式指定） |
+
+临时关闭 Codex 委托执行（PowerShell）：
+
+```powershell
+$env:CURSOR_BRIDGE_DELEGATION='off'
+codex
+```
+
+关闭后 `cursor-delegate` skill 必须由主 Agent 直接完成任务，不得尝试绕过或要求重新启用。删除该环境变量或设为 `on`，再重启客户端即可恢复。
 
 ## 使用建议
 

--- a/dist/cursor-bridge.mjs
+++ b/dist/cursor-bridge.mjs
@@ -19332,6 +19332,10 @@ import { pathToFileURL as pathToFileURL2 } from "url";
 var CDP_PORT2 = Number(process.env.CURSOR_BRIDGE_CDP_PORT || 9223);
 var ORIGIN = `http://localhost:${CDP_PORT2}`;
 var QUERY_TIMEOUT = Number(process.env.CURSOR_BRIDGE_TIMEOUT || 18e4);
+function normalizeDelegationMode(value = process.env.CURSOR_BRIDGE_DELEGATION) {
+  return String(value || "on").trim().toLowerCase() === "off" ? "off" : "on";
+}
+var DELEGATION_MODE = normalizeDelegationMode();
 var SEARCH_PREFIX = "\u53EA\u505A\u4EE3\u7801\u68C0\u7D22\u5B9A\u4F4D\uFF1A\u5217\u51FA\u4E0E\u4E0B\u9762\u610F\u56FE\u76F8\u5173\u7684\u6587\u4EF6\u8DEF\u5F84 + \u884C\u53F7\u8303\u56F4\uFF08\u5F62\u5982 Assets/Scripts/X.cs:120-180\uFF09\uFF0C\u9010\u884C\u5217\u51FA\u5373\u53EF\u3002\u4E0D\u8981\u8BFB\u53D6\u6587\u4EF6\u6B63\u6587\u3001\u4E0D\u8981\u4FEE\u6539\u4EFB\u4F55\u4EE3\u7801\u3001\u4E0D\u8981\u5C55\u5F00\u957F\u7BC7\u89E3\u91CA\u3002\n\n\u610F\u56FE\uFF1A";
 var DO_DEFAULT_CONTRACT = "\n\n\u5B8C\u6210\u8981\u6C42\uFF1A\u5728\u5F53\u524D Cursor \u5DF2\u6253\u5F00\u7684\u5DE5\u4F5C\u533A\u5185\u76F4\u63A5\u5B8C\u6210\u4EFB\u52A1\uFF1B\u4E0D\u8981\u63A8\u9001\u8FDC\u7AEF\u3002\u7ED3\u675F\u524D\u68C0\u67E5\u5B9E\u9645\u6539\u52A8\u5E76\u8FD0\u884C\u4E0E\u98CE\u9669\u5339\u914D\u7684\u9A8C\u8BC1\u3002\u6700\u7EC8\u56DE\u590D\u5FC5\u987B\u5217\u51FA\uFF1A\u5B8C\u6210\u5185\u5BB9\u3001\u6539\u52A8\u6587\u4EF6\u3001\u9A8C\u8BC1\u7ED3\u679C\u3001\u4ECD\u6709\u98CE\u9669\u6216\u963B\u585E\u3002";
 var CDP_HOST2 = "127.0.0.1";
@@ -19530,7 +19534,9 @@ function selectNewAgentEntry(beforeEntries, afterEntries) {
   return [...pool].sort((a, b) => Number(b.timestamp || 0) - Number(a.timestamp || 0) || b._index - a._index)[0];
 }
 var CursorBridge = class {
-  constructor() {
+  constructor(options = {}) {
+    this.delegationMode = normalizeDelegationMode(options.delegationMode || DELEGATION_MODE);
+    this.delegationEnabled = this.delegationMode !== "off";
     this.busy = false;
     this.queue = [];
     this._healing = null;
@@ -19553,6 +19559,9 @@ var CursorBridge = class {
     return job.promise;
   }
   async doTask(prompt, options = {}) {
+    if (!this.delegationEnabled) {
+      throw new Error("cursor_do \u5DF2\u901A\u8FC7 CURSOR_BRIDGE_DELEGATION=off \u7981\u7528\uFF1B\u8BF7\u7531\u4E3B Agent \u76F4\u63A5\u5B8C\u6210\u4EFB\u52A1");
+    }
     const text = String(prompt || "").trim();
     if (!text) throw new Error("prompt \u4E0D\u80FD\u4E3A\u7A7A");
     if (text.length > 1e5) throw new Error("prompt \u8FC7\u957F\uFF08\u6700\u5927 100000 \u5B57\u7B26\uFF09");
@@ -20164,12 +20173,14 @@ var CursorBridge = class {
   async status(taskId = "") {
     if (taskId) {
       const job = this.tasks.get(String(taskId));
-      if (!job) return { found: false, taskId: String(taskId) };
-      return { found: true, ...this._taskView(job, true) };
+      if (!job) return { found: false, taskId: String(taskId), delegationMode: this.delegationMode, delegationEnabled: this.delegationEnabled };
+      return { found: true, delegationMode: this.delegationMode, delegationEnabled: this.delegationEnabled, ...this._taskView(job, true) };
     }
     const parallelRunning = this.activeParallel.size;
     const uiBusy = this.busy;
     const common = {
+      delegationMode: this.delegationMode,
+      delegationEnabled: this.delegationEnabled,
       busy: uiBusy || parallelRunning > 0 || this.queue.length > 0,
       uiBusy,
       parallelRunning,
@@ -20189,7 +20200,7 @@ var CursorBridge = class {
   }
 };
 var bridge = new CursorBridge();
-var server = new Server({ name: "cursor-bridge", version: "2.0.7" }, { capabilities: { tools: {} } });
+var server = new Server({ name: "cursor-bridge", version: "2.1.1" }, { capabilities: { tools: {} } });
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [
     {
@@ -20203,7 +20214,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         required: ["query"]
       }
     },
-    {
+    bridge.delegationEnabled ? {
       name: "cursor_do",
       description: "\u628A\u8FB9\u754C\u660E\u786E\u7684\u4EFB\u52A1\u4EA4\u7ED9 Cursor agent \u6267\u884C\u3002\u9ED8\u8BA4 execution=fifo \u540E\u53F0\u6392\u961F\uFF1Bexecution=parallel_agent \u4F1A\u4E32\u884C\u64CD\u63A7 UI \u63D0\u4EA4\u5230\u72EC\u7ACB\u9876\u5C42 Agent\uFF0C\u518D\u6309\u7A33\u5B9A agentId \u5E76\u884C\u8DDF\u8E2A\u548C\u9010\u9879\u6536\u56DE\u3002\u5E76\u884C\u5199\u4EFB\u52A1\u5FC5\u987B\u63D0\u4F9B\u4E0D\u91CD\u53E0\u7684 allowed_paths\uFF1B\u53EA\u8BFB\u4EFB\u52A1\u5E94\u8BBE\u7F6E read_only=true\u3002\u7528 cursor_status(task_id) \u67E5\u8BE2\u72B6\u6001\u548C\u539F\u59CB\u56DE\u590D\u3002Cursor \u7ED3\u679C\u4E0D\u662F\u6B63\u5F0F\u9A8C\u8BC1\uFF0C\u4E3B Agent \u4ECD\u9700\u68C0\u67E5\u771F\u5B9E\u6539\u52A8\u3002",
       inputSchema: {
@@ -20220,7 +20231,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         },
         required: ["prompt"]
       }
-    },
+    } : null,
     {
       name: "cursor_status",
       description: "\u68C0\u67E5 Cursor CDP\u3001FIFO \u961F\u5217\u548C\u6D3B\u52A8\u5E76\u884C Agent\uFF1B\u4F20 task_id \u53EF\u7CBE\u786E\u67E5\u8BE2 cursor_do \u7684 agentId\u3001\u9636\u6BB5\u4E0E\u7ED3\u679C\u3002",
@@ -20231,7 +20242,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       description: "\u786E\u4FDD Cursor \u5E26 CDP \u8C03\u8BD5\u53E3(9223)\u5728\u8FD0\u884C\uFF1A\u672A\u8FD0\u884C\u5219\u81EA\u52A8\u62C9\u8D77\uFF08\u5E26 --remote-debugging-port + --remote-allow-origins + \u6253\u5F00\u672C\u9879\u76EE\u5EFA\u7D22\u5F15\uFF09\uFF1B\u5DF2\u5E26 flag \u5219\u76F4\u63A5\u8FD4\u56DE\u3002\u8FD4\u56DE status\uFF1Aalready / launched / running-no-debug\uFF08\u5728\u8DD1\u4F46\u6CA1\u5E26 flag\uFF0C\u9700\u5148\u5F7B\u5E95\u9000\u51FA Cursor\uFF09/ port-not-cursor\uFF089223 \u88AB\u522B\u7684 IDE \u5360\uFF09/ no-exe / timeout\u3002",
       inputSchema: { type: "object", properties: {} }
     }
-  ]
+  ].filter(Boolean)
 }));
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
@@ -20294,6 +20305,7 @@ export {
   CursorBridge,
   bridge,
   normalizeAllowedPath,
+  normalizeDelegationMode,
   pathsOverlap,
   selectNewAgentEntry
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cursor-mcp-bridge",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "MCP server for Cursor semantic search and bounded delegated execution over CDP, with FIFO and safe top-level Agent parallel modes.",
   "type": "module",
   "main": "server.mjs",

--- a/server.mjs
+++ b/server.mjs
@@ -30,6 +30,12 @@ const CDP_PORT = Number(process.env.CURSOR_BRIDGE_CDP_PORT || 9223);
 const ORIGIN = `http://localhost:${CDP_PORT}`;
 const QUERY_TIMEOUT = Number(process.env.CURSOR_BRIDGE_TIMEOUT || 180000);
 
+function normalizeDelegationMode(value = process.env.CURSOR_BRIDGE_DELEGATION) {
+  return String(value || 'on').trim().toLowerCase() === 'off' ? 'off' : 'on';
+}
+
+const DELEGATION_MODE = normalizeDelegationMode();
+
 // 只读检索 prompt：Cursor agent 当精准定位器用，约束操作类型（不读正文/不改码/不长篇），由 CC 拿清单后自己读真文件。
 const SEARCH_PREFIX =
   '只做代码检索定位：列出与下面意图相关的文件路径 + 行号范围（形如 Assets/Scripts/X.cs:120-180），' +
@@ -208,7 +214,9 @@ function selectNewAgentEntry(beforeEntries, afterEntries) {
 }
 
 class CursorBridge {
-  constructor() {
+  constructor(options = {}) {
+    this.delegationMode = normalizeDelegationMode(options.delegationMode || DELEGATION_MODE);
+    this.delegationEnabled = this.delegationMode !== 'off';
     this.busy = false;
     this.queue = [];
     this._healing = null;
@@ -233,6 +241,9 @@ class CursorBridge {
   }
 
   async doTask(prompt, options = {}) {
+    if (!this.delegationEnabled) {
+      throw new Error('cursor_do 已通过 CURSOR_BRIDGE_DELEGATION=off 禁用；请由主 Agent 直接完成任务');
+    }
     const text = String(prompt || '').trim();
     if (!text) throw new Error('prompt 不能为空');
     if (text.length > 100000) throw new Error('prompt 过长（最大 100000 字符）');
@@ -862,12 +873,14 @@ class CursorBridge {
   async status(taskId = '') {
     if (taskId) {
       const job = this.tasks.get(String(taskId));
-      if (!job) return { found: false, taskId: String(taskId) };
-      return { found: true, ...this._taskView(job, true) };
+      if (!job) return { found: false, taskId: String(taskId), delegationMode: this.delegationMode, delegationEnabled: this.delegationEnabled };
+      return { found: true, delegationMode: this.delegationMode, delegationEnabled: this.delegationEnabled, ...this._taskView(job, true) };
     }
     const parallelRunning = this.activeParallel.size;
     const uiBusy = this.busy;
     const common = {
+      delegationMode: this.delegationMode,
+      delegationEnabled: this.delegationEnabled,
       busy: uiBusy || parallelRunning > 0 || this.queue.length > 0,
       uiBusy,
       parallelRunning,
@@ -888,7 +901,7 @@ class CursorBridge {
 }
 
 const bridge = new CursorBridge();
-const server = new Server({ name: 'cursor-bridge', version: '2.0.7' }, { capabilities: { tools: {} } });
+const server = new Server({ name: 'cursor-bridge', version: '2.1.1' }, { capabilities: { tools: {} } });
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [
@@ -909,7 +922,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         required: ['query'],
       },
     },
-    {
+    bridge.delegationEnabled ? {
       name: 'cursor_do',
       description:
         '把边界明确的任务交给 Cursor agent 执行。默认 execution=fifo 后台排队；' +
@@ -930,7 +943,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         },
         required: ['prompt'],
       },
-    },
+    } : null,
     {
       name: 'cursor_status',
       description: '检查 Cursor CDP、FIFO 队列和活动并行 Agent；传 task_id 可精确查询 cursor_do 的 agentId、阶段与结果。',
@@ -943,7 +956,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         '返回 status：already / launched / running-no-debug（在跑但没带 flag，需先彻底退出 Cursor）/ port-not-cursor（9223 被别的 IDE 占）/ no-exe / timeout。',
       inputSchema: { type: 'object', properties: {} },
     },
-  ],
+  ].filter(Boolean),
 }));
 
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
@@ -1003,4 +1016,4 @@ if (isMain) {
   process.on('SIGINT', () => process.exit(0));
   main().catch((e) => { console.error('❌ 致命错误:', e); process.exit(1); });
 }
-export { CursorBridge, bridge, normalizeAllowedPath, pathsOverlap, selectNewAgentEntry };
+export { CursorBridge, bridge, normalizeAllowedPath, normalizeDelegationMode, pathsOverlap, selectNewAgentEntry };

--- a/skills/cursor-delegate/SKILL.md
+++ b/skills/cursor-delegate/SKILL.md
@@ -1,11 +1,17 @@
 ---
 name: cursor-delegate
-description: "将主 Agent 已规划、边界明确且可独立验收的中轻型实现、文档、配置或工具任务委托给 Cursor Bridge；支持 execution=fifo 串行执行，以及仅在任务互不依赖、写入路径不重叠时使用 execution=parallel_agent 派发多个顶层 Cursor Agent，再按 task_id/agent_id 收回并由主 Agent 复核。Use when planned execution work is ready to hand off, the user asks Cursor to execute bounded work, or several independent tasks can run concurrently. Do not use to delegate product direction, scope or architecture decisions, Unity Scene/Prefab or PlayMode operations, formal verification verdicts, Tower state decisions, or unbounded investigation."
+description: "将主 Agent 已规划、边界明确且可独立验收的中轻型实现、文档、配置或工具任务委托给 Cursor Bridge；支持 execution=fifo 串行执行，以及仅在任务互不依赖、写入路径不重叠时使用 execution=parallel_agent 派发多个顶层 Cursor Agent，再按 task_id/agent_id 收回并由主 Agent 复核。Use when planned execution work is ready to hand off, the user asks Cursor to execute bounded work, or several independent tasks can run concurrently. Do not use when the user opts out, cursor_do is unavailable, CURSOR_BRIDGE_DELEGATION=off, or for product direction, architecture decisions, Unity Scene/Prefab or PlayMode operations, formal verification verdicts, Tower state decisions, or unbounded investigation."
 ---
 
 # Cursor Delegate
 
 把 Cursor 当作执行副手。主 Agent 始终保留方向判断、范围裁决、结果审查和正式验证。
+
+## 尊重委托开关
+
+- 用户明确说“不使用 Cursor”“不要委托”或等价指令时，禁止调用 `cursor_do`；该否决高于本 skill 的默认工作流。
+- `cursor_do` 未出现在可用工具中，或 `cursor_status` 返回 `delegationMode=off` 时，不尝试绕过、重新启用或反复调用；由主 Agent 直接完成任务。
+- `CURSOR_BRIDGE_DELEGATION=off` 只关闭委托执行，不代表 `cursor_search`、`cursor_status` 或 `cursor_launch` 不可用。
 
 ## 日常默认工作流
 
@@ -15,7 +21,7 @@ description: "将主 Agent 已规划、边界明确且可独立验收的中轻�
 
 - 主 Agent 决定做什么、为什么做、允许改哪里、如何验收；不要把这些判断转交 Cursor。
 - Cursor 负责已决定方案内的检索、窄实现、文档、配置、脚本和工具修改。
-- 默认一项任务调用一次 `cursor_do`，使用 `background=true`、`new_chat=true`；主 Agent 可在后台继续不冲突的工作。
+- 委托开启时，默认一项任务调用一次 `cursor_do`，使用 `background=true`、`new_chat=true`；主 Agent 可在后台继续不冲突的工作。
 - 默认选择 `execution=fifo`。只有确实需要同时推进且满足并行合同的任务才使用 `parallel_agent`。
 - 不注入唯一终止标记，不设置最小回复长度。完成判断只依赖任务状态、稳定 `task_id/agent_id` 和实际结果。
 

--- a/skills/cursor-delegate/agents/openai.yaml
+++ b/skills/cursor-delegate/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Cursor 委托执行"
-  short_description: "将已规划的中轻型任务委托给 Cursor，支持安全并行、收回与复核"
-  default_prompt: "使用 $cursor-delegate 将这组已规划、边界明确的中轻型任务安全委托给 Cursor，并逐项收回和复核结果。"
+  short_description: "在委托开启时把已规划任务交给 Cursor，支持安全并行、收回与复核"
+  default_prompt: "在 cursor_do 可用且用户未禁用委托时，使用 $cursor-delegate 将这组已规划、边界明确的中轻型任务安全交给 Cursor；否则由主 Agent 直接完成。"
 
 dependencies:
   tools:

--- a/skills/cursor-delegate/references/delegation-contract.md
+++ b/skills/cursor-delegate/references/delegation-contract.md
@@ -2,6 +2,12 @@
 
 只在构造任务信封、选择 `execution` 或处理异常状态时读取本文件。
 
+## 委托开关
+
+- `CURSOR_BRIDGE_DELEGATION=off` 时，Bridge 不暴露 `cursor_do`，直接调用也必须失败；其他检索、状态和启动工具继续可用。
+- 用户明确拒绝委托、`cursor_do` 不可用或 `cursor_status.delegationMode=off` 时，主 Agent 直接执行，不得要求用户重新开启，也不得用其他调用绕过。
+- 重新开启需要以 `CURSOR_BRIDGE_DELEGATION=on` 或未设置该变量启动新的 MCP server 进程；运行中的进程不动态切换。
+
 ## 任务信封
 
 每项任务必须独立提供：

--- a/test/bridge.test.mjs
+++ b/test/bridge.test.mjs
@@ -1,9 +1,14 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 
 import {
   CursorBridge,
   normalizeAllowedPath,
+  normalizeDelegationMode,
   pathsOverlap,
   selectNewAgentEntry,
 } from '../server.mjs';
@@ -20,6 +25,48 @@ test('allowed path normalization and prefix overlap are deterministic', () => {
   assert.equal(pathsOverlap('Assets/Foo', './Assets/Bar/../Foo'), true);
   assert.equal(pathsOverlap('Assets/Scripts/A', 'Assets/Scripts/B'), false);
   assert.equal(pathsOverlap('.', 'Assets/Scripts'), true);
+});
+
+test('delegation mode recognizes only explicit off and otherwise stays enabled', () => {
+  assert.equal(normalizeDelegationMode('off'), 'off');
+  assert.equal(normalizeDelegationMode(' OFF '), 'off');
+  assert.equal(normalizeDelegationMode('on'), 'on');
+  assert.equal(normalizeDelegationMode('false'), 'on');
+  assert.equal(normalizeDelegationMode(''), 'on');
+});
+
+test('disabled delegation rejects cursor_do before Cursor access', async () => {
+  const bridge = new OfflineBridge({ delegationMode: 'off' });
+  assert.equal(bridge.delegationEnabled, false);
+  await assert.rejects(bridge.doTask('不应派发'), /CURSOR_BRIDGE_DELEGATION=off/);
+  const missing = await bridge.status('cursor-missing');
+  assert.equal(missing.delegationMode, 'off');
+  assert.equal(missing.delegationEnabled, false);
+});
+
+test('bundled MCP hides cursor_do in off mode and rejects direct calls', async () => {
+  const serverPath = fileURLToPath(new URL('../dist/cursor-bridge.mjs', import.meta.url));
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [serverPath],
+    env: {
+      ...process.env,
+      CURSOR_BRIDGE_DELEGATION: 'off',
+      CURSOR_BRIDGE_NO_AUTOLAUNCH: '1',
+    },
+  });
+  const client = new Client({ name: 'cursor-bridge-test', version: '1.0.0' });
+  try {
+    await client.connect(transport);
+    const listed = await client.listTools();
+    assert.equal(listed.tools.some((tool) => tool.name === 'cursor_do'), false);
+    assert.equal(listed.tools.some((tool) => tool.name === 'cursor_search'), true);
+    const blocked = await client.callTool({ name: 'cursor_do', arguments: { prompt: '不应执行' } });
+    assert.equal(blocked.isError, true);
+    assert.match(blocked.content[0].text, /CURSOR_BRIDGE_DELEGATION=off/);
+  } finally {
+    await client.close();
+  }
 });
 
 test('new agent selection uses ID diff, selected entry, then newest timestamp', () => {


### PR DESCRIPTION
## What changed

- add `CURSOR_BRIDGE_DELEGATION=off` as a process-level delegation kill switch
- hide `cursor_do` from MCP tool discovery while keeping search, status, and launch tools available
- reject direct `cursor_do` calls defensively when delegation is disabled
- expose `delegationMode` and `delegationEnabled` through `cursor_status`
- make the shared `cursor-delegate` skill respect user opt-out, unavailable tools, and off mode
- align Claude Code and Codex manifests and bump the dual-runtime plugin to `2.1.1`

## Validation

- `npm run build`
- `npm test` - 11/11 passed, including bundled MCP discovery and direct-call rejection in off mode
- `node --check server.mjs`
- `node --check dist/cursor-bridge.mjs`
- skill and plugin validators
- `claude plugin validate .`
- four-way version consistency check