### PR TITLE
chore: stop hardcoding npm account name in publish script

### DIFF
--- a/scripts/publish-pi-packages.ps1
+++ b/scripts/publish-pi-packages.ps1
@@ -28,11 +28,15 @@ if ($runningInGitHubActions) {
     }
     Write-Host 'Using npm Trusted Publishing (OIDC); npm whoami is intentionally skipped because OIDC is exchanged only during npm publish.' -ForegroundColor DarkGray
 } else {
+    $expectedNpmUser = ([string]$env:NPM_EXPECTED_USER).Trim()
+    if ([string]::IsNullOrWhiteSpace($expectedNpmUser)) {
+        throw 'Set NPM_EXPECTED_USER before local publish.'
+    }
     $npmUserOutput = @(& $NpmCommand whoami 2>&1)
     $npmWhoamiExitCode = $LASTEXITCODE
     $npmUser = ([string]($npmUserOutput | Select-Object -Last 1)).Trim()
-    if ($npmWhoamiExitCode -ne 0 -or $npmUser -ne 'flyingmoonc') {
-        throw "Expected npm account flyingmoonc, received '$npmUser'."
+    if ($npmWhoamiExitCode -ne 0 -or $npmUser -ne $expectedNpmUser) {
+        throw "Expected npm account $expectedNpmUser, received '$npmUser'."
     }
 }
 

--- a/test/pi-packages.test.mjs
+++ b/test/pi-packages.test.mjs
@@ -61,7 +61,7 @@ if (command === "publish") {
 }
 
 if (command === "whoami") {
-  console.log("flyingmoonc");
+  console.log(process.env.NPM_EXPECTED_USER || "publisher");
   process.exit(0);
 }
 
@@ -172,9 +172,9 @@ test("Pi publisher uses GitHub Actions OIDC without weakening local account veri
   assert.match(script, /\^\(\?:X\+\-\?\)\+\$/);
   assert.match(script, /must use npm Trusted Publishing without a real NODE_AUTH_TOKEN or NPM_TOKEN/);
   assert.match(script, /npm whoami is intentionally skipped/);
-  assert.match(script, /else \{\s+\$npmUserOutput = @\(& \$NpmCommand whoami 2>&1\)/);
+  assert.match(script, /else \{\s+\$expectedNpmUser = \(\[string\]\$env:NPM_EXPECTED_USER\)\.Trim\(\)/);
   assert.match(script, /\$npmUserOutput = @\(& \$NpmCommand whoami 2>&1\)/);
-  assert.match(script, /\$npmUser -ne 'flyingmoonc'/);
+  assert.match(script, /NPM_EXPECTED_USER/);
   assert.doesNotMatch(script, /\(& npm whoami\)\.Trim\(\)/);
   assert.match(script, /\[ValidateSet\('pi-cursor-bridge', 'pi-grok-build-supervisor'\)\]/);
   assert.match(script, /\[string\[\]\]\$PackageName/);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Local Pi package publish no longer assumes a single hardcoded npm login name.

- `scripts/publish-pi-packages.ps1` now requires `NPM_EXPECTED_USER` for the local (non-GitHub Actions) path. If it is unset or empty, the script throws `Set NPM_EXPECTED_USER before local publish.` Otherwise `npm whoami` must equal that value.
- The GitHub Actions Trusted Publishing / OIDC path is unchanged and still skips `npm whoami`.
- `test/pi-packages.test.mjs` no longer hardcodes `flyingmoonc` in the fake `whoami` helper or script-contract assertions.

Package names, package `author` metadata, and publish behavior were not changed. Nothing was published.

## Test plan
- [x] `node --test test/pi-packages.test.mjs` — static contract tests and OIDC success-path publisher tests pass
- [x] Manual local-path checks with a fake `npm whoami`:
  - unset `NPM_EXPECTED_USER` → `Set NPM_EXPECTED_USER before local publish.`
  - mismatch → expected-account error
  - match → whoami check passes
  - `GITHUB_ACTIONS=true` → Trusted Publishing skip message, no whoami account error
- [ ] Note: three existing publisher error-message regexes wrap on Linux pwsh 7.6.5 (`NODE_AUTH_TOKEN` / `already exists on npm` / `published tarball`). Those strings are unchanged and the Trusted Publishing branch was not edited.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f208788-27a0-4675-8b7c-3560c3c2b1d5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f208788-27a0-4675-8b7c-3560c3c2b1d5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

